### PR TITLE
Hotfix for the Total Communication Cost C metric implementation

### DIFF
--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleFatTree.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleFatTree.java
@@ -14,6 +14,7 @@ import generators.config.OneTierConfig;
 import metrics.embedding.AcceptedVnrMetric;
 import metrics.embedding.AveragePathLengthMetric;
 import metrics.embedding.TotalCommunicationCostMetricA;
+import metrics.embedding.TotalCommunicationCostMetricC;
 import metrics.embedding.TotalCommunicationCostObjectiveC;
 import metrics.embedding.TotalPathCostMetric;
 import metrics.manager.GlobalMetricsManager;
@@ -93,8 +94,10 @@ public class VnePmMdvneAlgorithmExampleFatTree {
 		System.out.println("=> Average path length: " + averagePathLength.getValue());
 		final TotalCommunicationCostMetricA tcca = new TotalCommunicationCostMetricA(sNet);
 		System.out.println("=> Total Communication Cost A: " + tcca.getValue());
-		final TotalCommunicationCostObjectiveC tccc = new TotalCommunicationCostObjectiveC(sNet);
-		System.out.println("=> Total Communication Objective C: " + tccc.getValue());
+		final TotalCommunicationCostMetricC tccc = new TotalCommunicationCostMetricC(sNet);
+		System.out.println("=> Total Communication Metric C: " + tccc.getValue());
+		final TotalCommunicationCostObjectiveC tcoc = new TotalCommunicationCostObjectiveC(sNet);
+		System.out.println("=> Total Communication Objective C: " + tcoc.getValue());
 
 		System.exit(0);
 	}

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleFatTree.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleFatTree.java
@@ -14,7 +14,7 @@ import generators.config.OneTierConfig;
 import metrics.embedding.AcceptedVnrMetric;
 import metrics.embedding.AveragePathLengthMetric;
 import metrics.embedding.TotalCommunicationCostMetricA;
-import metrics.embedding.TotalCommunicationCostMetricC;
+import metrics.embedding.TotalCommunicationCostObjectiveC;
 import metrics.embedding.TotalPathCostMetric;
 import metrics.manager.GlobalMetricsManager;
 import model.SubstrateNetwork;
@@ -93,8 +93,8 @@ public class VnePmMdvneAlgorithmExampleFatTree {
 		System.out.println("=> Average path length: " + averagePathLength.getValue());
 		final TotalCommunicationCostMetricA tcca = new TotalCommunicationCostMetricA(sNet);
 		System.out.println("=> Total Communication Cost A: " + tcca.getValue());
-		final TotalCommunicationCostMetricC tccc = new TotalCommunicationCostMetricC(sNet);
-		System.out.println("=> Total Communication Cost C: " + tccc.getValue());
+		final TotalCommunicationCostObjectiveC tccc = new TotalCommunicationCostObjectiveC(sNet);
+		System.out.println("=> Total Communication Objective C: " + tccc.getValue());
 
 		System.exit(0);
 	}

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleTwoTier.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleTwoTier.java
@@ -14,7 +14,7 @@ import generators.config.TwoTierConfig;
 import metrics.embedding.AcceptedVnrMetric;
 import metrics.embedding.AveragePathLengthMetric;
 import metrics.embedding.TotalCommunicationCostMetricA;
-import metrics.embedding.TotalCommunicationCostMetricC;
+import metrics.embedding.TotalCommunicationCostObjectiveC;
 import metrics.embedding.TotalPathCostMetric;
 import metrics.manager.GlobalMetricsManager;
 import model.SubstrateNetwork;
@@ -93,8 +93,8 @@ public class VnePmMdvneAlgorithmExampleTwoTier {
 		System.out.println("=> Average path length: " + averagePathLength.getValue());
 		final TotalCommunicationCostMetricA tcca = new TotalCommunicationCostMetricA(sNet);
 		System.out.println("=> Total Communication Cost A: " + tcca.getValue());
-		final TotalCommunicationCostMetricC tccc = new TotalCommunicationCostMetricC(sNet);
-		System.out.println("=> Total Communication Cost C: " + tccc.getValue());
+		final TotalCommunicationCostObjectiveC tccc = new TotalCommunicationCostObjectiveC(sNet);
+		System.out.println("=> Total Communication Objective C: " + tccc.getValue());
 
 		System.exit(0);
 	}

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleTwoTier.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleTwoTier.java
@@ -14,6 +14,7 @@ import generators.config.TwoTierConfig;
 import metrics.embedding.AcceptedVnrMetric;
 import metrics.embedding.AveragePathLengthMetric;
 import metrics.embedding.TotalCommunicationCostMetricA;
+import metrics.embedding.TotalCommunicationCostMetricC;
 import metrics.embedding.TotalCommunicationCostObjectiveC;
 import metrics.embedding.TotalPathCostMetric;
 import metrics.manager.GlobalMetricsManager;
@@ -93,8 +94,10 @@ public class VnePmMdvneAlgorithmExampleTwoTier {
 		System.out.println("=> Average path length: " + averagePathLength.getValue());
 		final TotalCommunicationCostMetricA tcca = new TotalCommunicationCostMetricA(sNet);
 		System.out.println("=> Total Communication Cost A: " + tcca.getValue());
-		final TotalCommunicationCostObjectiveC tccc = new TotalCommunicationCostObjectiveC(sNet);
-		System.out.println("=> Total Communication Objective C: " + tccc.getValue());
+		final TotalCommunicationCostMetricC tccc = new TotalCommunicationCostMetricC(sNet);
+		System.out.println("=> Total Communication Metric C: " + tccc.getValue());
+		final TotalCommunicationCostObjectiveC tcoc = new TotalCommunicationCostObjectiveC(sNet);
+		System.out.println("=> Total Communication Objective C: " + tcoc.getValue());
 
 		System.exit(0);
 	}

--- a/network.metrics/src/metrics/CostUtility.java
+++ b/network.metrics/src/metrics/CostUtility.java
@@ -131,7 +131,8 @@ public class CostUtility {
 
 	/**
 	 * Returns the adapted total communication cost for a node to node embedding.
-	 * This one prefers already filled up substrate servers over empty ones.
+	 * (This one is used by the OBJECTIVE.) This one prefers already filled up
+	 * substrate servers over empty ones.
 	 *
 	 * @param virtualElement   Virtual node to embed.
 	 * @param substrateElement Substrate node to embed.
@@ -150,8 +151,27 @@ public class CostUtility {
 	}
 
 	/**
+	 * Returns the adapted total communication cost for substrate server. (This one
+	 * is used by the METRIC.) This one prefers already filled up substrate servers
+	 * over empty ones.
+	 *
+	 * @param substrateElement Substrate node to embed.
+	 * @return Cost for this particular mapping.
+	 */
+	public static double getTotalCommunicationCostMetricNodeC(final SubstrateElement substrateElement) {
+		if (substrateElement instanceof SubstrateServer) {
+			final SubstrateServer ssrv = (SubstrateServer) substrateElement;
+			return 1.0 * ssrv.getResidualCpu() / ssrv.getCpu() + 1.0 * ssrv.getResidualMemory() / ssrv.getMemory()
+					+ 1.0 * ssrv.getResidualStorage() / ssrv.getStorage();
+		}
+
+		return 0;
+	}
+
+	/**
 	 * Returns the adapted total communication cost for a node to node embedding.
-	 * This one prefers empty substrate servers over non-empty ones.
+	 * (This one is used by the OBJECTIVE.) This one prefers empty substrate servers
+	 * over non-empty ones.
 	 *
 	 * @param virtualElement   Virtual node to embed.
 	 * @param substrateElement Substrate node to embed.
@@ -161,6 +181,22 @@ public class CostUtility {
 			final SubstrateElement substrateElement) {
 		if (virtualElement instanceof VirtualServer && substrateElement instanceof SubstrateServer) {
 			return 1.0 / getTotalCommunicationCostObjectiveNodeC(virtualElement, substrateElement);
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Returns the adapted total communication cost for a node to node embedding.
+	 * (This one is used by the METRIC.) This one prefers empty substrate servers
+	 * over non-empty ones.
+	 *
+	 * @param substrateElement Substrate node to embed.
+	 * @return Cost for this particular mapping.
+	 */
+	public static double getTotalCommunicationCostMetricNodeD(final SubstrateElement substrateElement) {
+		if (substrateElement instanceof SubstrateServer) {
+			return 1.0 / getTotalCommunicationCostMetricNodeC(substrateElement);
 		}
 
 		return 0;

--- a/network.metrics/src/metrics/CostUtility.java
+++ b/network.metrics/src/metrics/CostUtility.java
@@ -137,7 +137,7 @@ public class CostUtility {
 	 * @param substrateElement Substrate node to embed.
 	 * @return Cost for this particular mapping.
 	 */
-	public static double getTotalCommunicationCostNodeC(final VirtualElement virtualElement,
+	public static double getTotalCommunicationCostObjectiveNodeC(final VirtualElement virtualElement,
 			final SubstrateElement substrateElement) {
 		if (virtualElement instanceof VirtualServer && substrateElement instanceof SubstrateServer) {
 			// final VirtualServer vsrv = (VirtualServer) virtualElement;
@@ -157,10 +157,10 @@ public class CostUtility {
 	 * @param substrateElement Substrate node to embed.
 	 * @return Cost for this particular mapping.
 	 */
-	public static double getTotalCommunicationCostNodeD(final VirtualElement virtualElement,
+	public static double getTotalCommunicationCostObjectiveNodeD(final VirtualElement virtualElement,
 			final SubstrateElement substrateElement) {
 		if (virtualElement instanceof VirtualServer && substrateElement instanceof SubstrateServer) {
-			return 1.0 / getTotalCommunicationCostNodeC(virtualElement, substrateElement);
+			return 1.0 / getTotalCommunicationCostObjectiveNodeC(virtualElement, substrateElement);
 		}
 
 		return 0;

--- a/network.metrics/src/metrics/CostUtility.java
+++ b/network.metrics/src/metrics/CostUtility.java
@@ -23,6 +23,12 @@ import model.VirtualServer;
 public class CostUtility {
 
 	/**
+	 * Private constructor to forbid instantiation.
+	 */
+	private CostUtility() {
+	}
+
+	/**
 	 * Returns the total path cost for a link to path/server embedding.
 	 *
 	 * Implementation of the cost function of paper [1].

--- a/network.metrics/src/metrics/embedding/TotalCommunicationCostMetricC.java
+++ b/network.metrics/src/metrics/embedding/TotalCommunicationCostMetricC.java
@@ -1,0 +1,84 @@
+package metrics.embedding;
+
+import java.util.List;
+
+import metrics.CostUtility;
+import metrics.IMetric;
+import model.Link;
+import model.Node;
+import model.SubstrateNetwork;
+import model.SubstrateServer;
+import model.VirtualLink;
+import model.VirtualNetwork;
+
+/**
+ * Implementation of the cost function of paper [1] and [2]. In comparison to
+ * the paper [1], we define the cost of one hop as 1 as stated in [2]. Node
+ * embedding of servers is defined as decreasing function for substrate server
+ * filling. This means, that an almost full substrate server is "cheaper" than
+ * an empty one.
+ * 
+ * Please notice: This "metric" checks every substrate server (not just the ones
+ * with embeddings on them!).
+ *
+ * [1] Meng, Xiaoqiao, Vasileios Pappas, and Li Zhang. "Improving the
+ * scalability of data center networks with traffic-aware virtual machine
+ * placement." 2010 Proceedings IEEE INFOCOM. IEEE, 2010.
+ *
+ * [2] M. G. Rabbani, R. P. Esteves, M. Podlesny, G. Simon, L. Z. Granville and
+ * R. Boutaba, "On tackling virtual data center embedding problem," 2013
+ * IFIP/IEEE International Symposium on Integrated Network Management (IM 2013),
+ * 2013, pp. 177-184.
+ *
+ * From the paper [1]: "For the sake of illustration, we define C_ij as the
+ * number of switches on the routing path from VM i to j."
+ *
+ * From the paper [2]: "We consider the hop-count between the virtual nodes
+ * (i.e., VM or virtual switch) multiplied by the corresponding requested
+ * bandwidth of the virtual link connecting the two virtual nodes"
+ *
+ * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
+ */
+public class TotalCommunicationCostMetricC implements IMetric {
+
+	/**
+	 * Calculated cost.
+	 */
+	private double cost;
+
+	/**
+	 * Creates a new instance of this metric for the provided substrate network.
+	 *
+	 * @param sNet Substrate network to calculate the metric for.
+	 */
+	public TotalCommunicationCostMetricC(final SubstrateNetwork sNet) {
+		double cost = 0;
+
+		// Iterate over all virtual networks that are embedded on the substrate network
+		for (final VirtualNetwork vNet : sNet.getGuests()) {
+			final List<Link> guestLinks = facade.getAllLinksOfNetwork(vNet.getName());
+
+			// Iterate over all virtual links
+			for (final Link l : guestLinks) {
+				final VirtualLink vl = (VirtualLink) l;
+				cost += CostUtility.getTotalCommunicationCostLinkBCD(vl, vl.getHost());
+			}
+
+			final List<Node> substrateServers = facade.getAllServersOfNetwork(sNet.getName());
+
+			// Iterate over all substrate servers
+			for (final Node s : substrateServers) {
+				final SubstrateServer srv = (SubstrateServer) s;
+				cost += CostUtility.getTotalCommunicationCostMetricNodeC(srv);
+			}
+		}
+
+		this.cost = cost;
+	}
+
+	@Override
+	public double getValue() {
+		return cost;
+	}
+
+}

--- a/network.metrics/src/metrics/embedding/TotalCommunicationCostMetricD.java
+++ b/network.metrics/src/metrics/embedding/TotalCommunicationCostMetricD.java
@@ -1,0 +1,84 @@
+package metrics.embedding;
+
+import java.util.List;
+
+import metrics.CostUtility;
+import metrics.IMetric;
+import model.Link;
+import model.Node;
+import model.SubstrateNetwork;
+import model.SubstrateServer;
+import model.VirtualLink;
+import model.VirtualNetwork;
+
+/**
+ * Implementation of the cost function of paper [1] and [2]. In comparison to
+ * the paper [1], we define the cost of one hop as 1 as stated in [2]. Node
+ * embedding of servers is defined as increasing function for substrate server
+ * filling. This means, that an almost full substrate server is more "expensive"
+ * than an empty one.
+ * 
+ * Please notice: This "metric" checks every substrate server (not just the ones
+ * with embeddings on them!).
+ *
+ * [1] Meng, Xiaoqiao, Vasileios Pappas, and Li Zhang. "Improving the
+ * scalability of data center networks with traffic-aware virtual machine
+ * placement." 2010 Proceedings IEEE INFOCOM. IEEE, 2010.
+ *
+ * [2] M. G. Rabbani, R. P. Esteves, M. Podlesny, G. Simon, L. Z. Granville and
+ * R. Boutaba, "On tackling virtual data center embedding problem," 2013
+ * IFIP/IEEE International Symposium on Integrated Network Management (IM 2013),
+ * 2013, pp. 177-184.
+ *
+ * From the paper [1]: "For the sake of illustration, we define C_ij as the
+ * number of switches on the routing path from VM i to j."
+ *
+ * From the paper [2]: "We consider the hop-count between the virtual nodes
+ * (i.e., VM or virtual switch) multiplied by the corresponding requested
+ * bandwidth of the virtual link connecting the two virtual nodes"
+ *
+ * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
+ */
+public class TotalCommunicationCostMetricD implements IMetric {
+
+	/**
+	 * Calculated cost.
+	 */
+	private double cost;
+
+	/**
+	 * Creates a new instance of this metric for the provided substrate network.
+	 *
+	 * @param sNet Substrate network to calculate the metric for.
+	 */
+	public TotalCommunicationCostMetricD(final SubstrateNetwork sNet) {
+		double cost = 0;
+
+		// Iterate over all virtual networks that are embedded on the substrate network
+		for (final VirtualNetwork vNet : sNet.getGuests()) {
+			final List<Link> guestLinks = facade.getAllLinksOfNetwork(vNet.getName());
+
+			// Iterate over all virtual links
+			for (final Link l : guestLinks) {
+				final VirtualLink vl = (VirtualLink) l;
+				cost += CostUtility.getTotalCommunicationCostLinkBCD(vl, vl.getHost());
+			}
+
+			final List<Node> substrateServers = facade.getAllServersOfNetwork(sNet.getName());
+
+			// Iterate over all substrate servers
+			for (final Node s : substrateServers) {
+				final SubstrateServer srv = (SubstrateServer) s;
+				cost += CostUtility.getTotalCommunicationCostMetricNodeD(srv);
+			}
+		}
+
+		this.cost = cost;
+	}
+
+	@Override
+	public double getValue() {
+		return cost;
+	}
+
+}

--- a/network.metrics/src/metrics/embedding/TotalCommunicationCostObjectiveC.java
+++ b/network.metrics/src/metrics/embedding/TotalCommunicationCostObjectiveC.java
@@ -14,9 +14,13 @@ import model.VirtualServer;
 /**
  * Implementation of the cost function of paper [1] and [2]. In comparison to
  * the paper [1], we define the cost of one hop as 1 as stated in [2]. Node
- * embedding of servers is defined as increasing function for substrate server
- * filling. This means, that an almost full substrate server is more "expensive"
- * than an empty one.
+ * embedding of servers is defined as decreasing function for substrate server
+ * filling. This means, that an almost full substrate server is "cheaper" than
+ * an empty one.
+ * 
+ * Please notice: This "metric" is only an objective function that deals with
+ * embedded virtual resources and their substrate hosts. For a "real" (patched)
+ * version of this, please refer to {@link TotalCommunicationCostMetricC}.
  *
  * [1] Meng, Xiaoqiao, Vasileios Pappas, and Li Zhang. "Improving the
  * scalability of data center networks with traffic-aware virtual machine
@@ -36,7 +40,7 @@ import model.VirtualServer;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class TotalCommunicationCostMetricD implements IMetric {
+public class TotalCommunicationCostObjectiveC implements IMetric {
 
 	/**
 	 * Calculated cost.
@@ -48,7 +52,7 @@ public class TotalCommunicationCostMetricD implements IMetric {
 	 *
 	 * @param sNet Substrate network to calculate the metric for.
 	 */
-	public TotalCommunicationCostMetricD(final SubstrateNetwork sNet) {
+	public TotalCommunicationCostObjectiveC(final SubstrateNetwork sNet) {
 		double cost = 0;
 
 		// Iterate over all virtual networks that are embedded on the substrate network
@@ -66,7 +70,7 @@ public class TotalCommunicationCostMetricD implements IMetric {
 			// Iterate over all virtual servers
 			for (final Node s : guestServers) {
 				final VirtualServer vs = (VirtualServer) s;
-				cost += CostUtility.getTotalCommunicationCostNodeD(vs, vs.getHost());
+				cost += CostUtility.getTotalCommunicationCostObjectiveNodeC(vs, vs.getHost());
 			}
 		}
 

--- a/network.metrics/src/metrics/embedding/TotalCommunicationCostObjectiveD.java
+++ b/network.metrics/src/metrics/embedding/TotalCommunicationCostObjectiveD.java
@@ -14,9 +14,13 @@ import model.VirtualServer;
 /**
  * Implementation of the cost function of paper [1] and [2]. In comparison to
  * the paper [1], we define the cost of one hop as 1 as stated in [2]. Node
- * embedding of servers is defined as decreasing function for substrate server
- * filling. This means, that an almost full substrate server is "cheaper" than
- * an empty one.
+ * embedding of servers is defined as increasing function for substrate server
+ * filling. This means, that an almost full substrate server is more "expensive"
+ * than an empty one.
+ * 
+ * Please notice: This "metric" is only an objective function that deals with
+ * embedded virtual resources and their substrate hosts. For a "real" (patched)
+ * version of this, please refer to {@link TotalCommunicationCostMetricD}.
  *
  * [1] Meng, Xiaoqiao, Vasileios Pappas, and Li Zhang. "Improving the
  * scalability of data center networks with traffic-aware virtual machine
@@ -36,7 +40,7 @@ import model.VirtualServer;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class TotalCommunicationCostMetricC implements IMetric {
+public class TotalCommunicationCostObjectiveD implements IMetric {
 
 	/**
 	 * Calculated cost.
@@ -48,7 +52,7 @@ public class TotalCommunicationCostMetricC implements IMetric {
 	 *
 	 * @param sNet Substrate network to calculate the metric for.
 	 */
-	public TotalCommunicationCostMetricC(final SubstrateNetwork sNet) {
+	public TotalCommunicationCostObjectiveD(final SubstrateNetwork sNet) {
 		double cost = 0;
 
 		// Iterate over all virtual networks that are embedded on the substrate network
@@ -66,7 +70,7 @@ public class TotalCommunicationCostMetricC implements IMetric {
 			// Iterate over all virtual servers
 			for (final Node s : guestServers) {
 				final VirtualServer vs = (VirtualServer) s;
-				cost += CostUtility.getTotalCommunicationCostNodeC(vs, vs.getHost());
+				cost += CostUtility.getTotalCommunicationCostObjectiveNodeD(vs, vs.getHost());
 			}
 		}
 

--- a/statistics/src/statistics/Runner.java
+++ b/statistics/src/statistics/Runner.java
@@ -55,13 +55,13 @@ public class Runner {
 		final String outputName = expName + "_stats.csv";
 
 		// Currently, the number of metrics is hard-coded against CsvUtil.java
-		double[] outputMean = new double[18];
-		double[] outputStdDev = new double[18];
+		double[] outputMean = new double[22];
+		double[] outputStdDev = new double[22];
 
 		// Iterate over all lines of the files
 		for (int v = 0; v < data.get(0).size(); v++) {
 			// Iterate over all metrics
-			for (int i = 0; i < 18; i++) {
+			for (int i = 0; i < 22; i++) {
 				final Double[] values = new Double[data.size()];
 
 				// Iterate over the data sets (= files)
@@ -76,7 +76,7 @@ public class Runner {
 				// If the metric is the last one -> Check if rounding of time_total and
 				// time_total_stddev is
 				// necessary
-				if (i == 17) {
+				if (i == 21) {
 					outputMean[i] = StatisticUtils.roundTimetotal(outputMean[i]);
 					outputStdDev[i] = StatisticUtils.roundTimetotalstddev(outputStdDev[i]);
 				}

--- a/test.suite/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalCommunicationObjectiveCTest.java
@@ -24,11 +24,11 @@ import test.algorithms.generic.AAlgorithmMultipleVnsTest;
 
 /**
  * Test class for the VNE fake ILP algorithm (incremental version)
- * implementation for minimizing the total communication cost metric C.
+ * implementation for minimizing the total communication cost objective C.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VneFakeIlpAlgorithmTotalCommunicationCostCTest extends AAlgorithmMultipleVnsTest {
+public class VneFakeIlpAlgorithmTotalCommunicationObjectiveCTest extends AAlgorithmMultipleVnsTest {
 
 	@AfterEach
 	public void resetAlgo() {
@@ -39,7 +39,7 @@ public class VneFakeIlpAlgorithmTotalCommunicationCostCTest extends AAlgorithmMu
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		AlgorithmConfig.emb = Embedding.MANUAL;
 		algo = VneFakeIlpAlgorithm.prepare(sNet, vNets);
 	}

--- a/test.suite/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalCommunicationObjectiveCTest.java
@@ -14,16 +14,16 @@ import model.VirtualNetwork;
 
 /**
  * Test class for the VNE fake ILP algorithm (batch version) implementation for
- * minimizing the total communication cost metric C.
+ * minimizing the total communication cost objective C.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VneFakeIlpBatchAlgorithmTotalCommunicationCostCTest
-		extends VneFakeIlpAlgorithmTotalCommunicationCostCTest {
+public class VneFakeIlpBatchAlgorithmTotalCommunicationObjectiveCTest
+		extends VneFakeIlpAlgorithmTotalCommunicationObjectiveCTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		AlgorithmConfig.emb = Embedding.MANUAL;
 		algo = VneFakeIlpBatchAlgorithm.prepare(sNet, vNets);
 	}

--- a/test.suite/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest.java
@@ -23,15 +23,15 @@ import test.algorithms.generic.AAlgorithmMultipleVnsTest;
 
 /**
  * Test class for the VNE PM MdVNE algorithm implementation for minimizing the
- * total communication cost metric C.
+ * total communication cost objective C.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmTotalCommunicationCostCTest extends AAlgorithmMultipleVnsTest {
+public class VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest extends AAlgorithmMultipleVnsTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
 	}
 

--- a/test.suite/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalCommunicationObjectiveCTest.java
@@ -7,20 +7,20 @@ import algorithms.AlgorithmConfig.Objective;
 import algorithms.pm.VnePmMdvneAlgorithmMigration;
 import model.SubstrateNetwork;
 import model.VirtualNetwork;
-import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationCostCTest;
+import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest;
 
 /**
  * Test class for the VNE PM MdVNE algorithm implementation for minimizing the
- * total communication cost metric C including the migration functionality.
+ * total communication cost objective C including the migration functionality.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmMigrationTotalCommunicationCostCTest
-		extends VnePmMdvneAlgorithmTotalCommunicationCostCTest {
+public class VnePmMdvneAlgorithmMigrationTotalCommunicationObjectiveCTest
+		extends VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
 	}
 

--- a/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationObjectiveCTest.java
@@ -7,20 +7,20 @@ import algorithms.AlgorithmConfig.Objective;
 import algorithms.pm.VnePmMdvneAlgorithmPipelineThreeStagesA;
 import model.SubstrateNetwork;
 import model.VirtualNetwork;
-import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationCostCTest;
+import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest;
 
 /**
  * Test class for the VNE PM MdVNE algorithm implementation for minimizing the
- * total communication cost metric C including the pipeline functionality.
+ * total communication cost objective C including the pipeline functionality.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationCostCTest
-		extends VnePmMdvneAlgorithmTotalCommunicationCostCTest {
+public class VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationObjectiveCTest
+		extends VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		algo = VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
 	}
 

--- a/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationObjectiveCTest.java
@@ -7,20 +7,20 @@ import algorithms.AlgorithmConfig.Objective;
 import algorithms.pm.VnePmMdvneAlgorithmPipelineThreeStagesB;
 import model.SubstrateNetwork;
 import model.VirtualNetwork;
-import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationCostCTest;
+import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest;
 
 /**
  * Test class for the VNE PM MdVNE algorithm implementation for minimizing the
- * total communication cost metric C including the pipeline functionality.
+ * total communication cost objective C including the pipeline functionality.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationCostCTest
-		extends VnePmMdvneAlgorithmTotalCommunicationCostCTest {
+public class VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationObjectiveCTest
+		extends VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		algo = VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
 	}
 

--- a/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationObjectiveCTest.java
@@ -9,20 +9,20 @@ import algorithms.AlgorithmConfig.Objective;
 import algorithms.pm.VnePmMdvneAlgorithmPipelineTwoStagesRackA;
 import model.SubstrateNetwork;
 import model.VirtualNetwork;
-import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationCostCTest;
+import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest;
 
 /**
  * Test class for the VNE PM MdVNE algorithm implementation for minimizing the
- * total communication cost metric C including the pipeline functionality.
+ * total communication cost objective C including the pipeline functionality.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationCostCTest
-		extends VnePmMdvneAlgorithmTotalCommunicationCostCTest {
+public class VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationObjectiveCTest
+		extends VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
 	}
 

--- a/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationObjectiveCTest.java
@@ -7,20 +7,20 @@ import algorithms.AlgorithmConfig.Objective;
 import algorithms.pm.VnePmMdvneAlgorithmPipelineTwoStagesRackB;
 import model.SubstrateNetwork;
 import model.VirtualNetwork;
-import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationCostCTest;
+import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest;
 
 /**
  * Test class for the VNE PM MdVNE algorithm implementation for minimizing the
- * total communication cost metric C including the pipeline functionality.
+ * total communication cost objective C including the pipeline functionality.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationCostCTest
-		extends VnePmMdvneAlgorithmTotalCommunicationCostCTest {
+public class VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationObjectiveCTest
+		extends VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
 	}
 

--- a/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationObjectiveCTest.java
+++ b/test.suite/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationObjectiveCTest.java
@@ -7,20 +7,20 @@ import algorithms.AlgorithmConfig.Objective;
 import algorithms.pm.VnePmMdvneAlgorithmPipelineTwoStagesVnet;
 import model.SubstrateNetwork;
 import model.VirtualNetwork;
-import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationCostCTest;
+import test.algorithms.pm.VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest;
 
 /**
  * Test class for the VNE PM MdVNE algorithm implementation for minimizing the
- * total communication cost metric C including the pipeline functionality.
+ * total communication cost objective C including the pipeline functionality.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationCostCTest
-		extends VnePmMdvneAlgorithmTotalCommunicationCostCTest {
+public class VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationObjectiveCTest
+		extends VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		algo = VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
 	}
 

--- a/test.suite/src/test/metrics/TotalCommunicationCostMetricCTest.java
+++ b/test.suite/src/test/metrics/TotalCommunicationCostMetricCTest.java
@@ -1,0 +1,50 @@
+package test.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import metrics.embedding.TotalCommunicationCostMetricC;
+import model.SubstrateNetwork;
+
+/**
+ * Test class for the metric of total communication cost as implemented in
+ * {@link TotalCommunicationCostMetricC}.
+ *
+ * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
+ */
+public class TotalCommunicationCostMetricCTest extends ATotalCommunicationCostMetricTest {
+
+	@Override
+	protected void setMetric(final SubstrateNetwork sNet) {
+		metric = new TotalCommunicationCostMetricC(sNet);
+	}
+
+	/*
+	 * Positive tests
+	 */
+
+	@Override
+	@Test
+	public void testEmbeddingTwoHosts() {
+		createSubstrateNetwork();
+		setupEmbeddingTwoHosts();
+		final SubstrateNetwork sNet = (SubstrateNetwork) facade.getNetworkById("sub");
+		setMetric(sNet);
+
+		assertEquals(2 * 2 * 3 + 3, metric.getValue());
+	}
+
+	@Override
+	@Test
+	public void testEmbeddingSameHost() {
+		createSubstrateNetwork();
+		setupEmbeddingSameHost();
+		final SubstrateNetwork sNet = (SubstrateNetwork) facade.getNetworkById("sub");
+		setMetric(sNet);
+
+		// Must be equal to 3, because there is an unused server.
+		assertEquals(3, metric.getValue());
+	}
+
+}

--- a/test.suite/src/test/metrics/TotalCommunicationCostMetricDTest.java
+++ b/test.suite/src/test/metrics/TotalCommunicationCostMetricDTest.java
@@ -1,0 +1,49 @@
+package test.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import metrics.embedding.TotalCommunicationCostMetricD;
+import model.SubstrateNetwork;
+
+/**
+ * Test class for the metric of total communication cost as implemented in
+ * {@link TotalCommunicationCostMetricD}.
+ *
+ * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
+ */
+public class TotalCommunicationCostMetricDTest extends ATotalCommunicationCostMetricTest {
+
+	@Override
+	protected void setMetric(final SubstrateNetwork sNet) {
+		metric = new TotalCommunicationCostMetricD(sNet);
+	}
+
+	/*
+	 * Positive tests
+	 */
+
+	@Override
+	@Test
+	public void testEmbeddingSameHost() {
+		createSubstrateNetwork();
+		setupEmbeddingSameHost();
+		final SubstrateNetwork sNet = (SubstrateNetwork) facade.getNetworkById("sub");
+		setMetric(sNet);
+
+		assertEquals(Double.POSITIVE_INFINITY, metric.getValue());
+	}
+
+	@Override
+	@Test
+	public void testEmbeddingTwoHosts() {
+		createSubstrateNetwork();
+		setupEmbeddingTwoHosts();
+		final SubstrateNetwork sNet = (SubstrateNetwork) facade.getNetworkById("sub");
+		setMetric(sNet);
+
+		assertEquals(13.333, metric.getValue(), 0.01);
+	}
+
+}

--- a/test.suite/src/test/metrics/TotalCommunicationCostObjectiveCTest.java
+++ b/test.suite/src/test/metrics/TotalCommunicationCostObjectiveCTest.java
@@ -4,36 +4,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import metrics.embedding.TotalCommunicationCostMetricD;
+import metrics.embedding.TotalCommunicationCostObjectiveC;
 import model.SubstrateNetwork;
 
 /**
  * Test class for the metric of total communication cost as implemented in
- * {@link TotalCommunicationCostMetricD}.
+ * {@link TotalCommunicationCostObjectiveC}.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class TotalCommunicationCostMetricDTest extends ATotalCommunicationCostMetricTest {
+public class TotalCommunicationCostObjectiveCTest extends ATotalCommunicationCostMetricTest {
 
 	@Override
 	protected void setMetric(final SubstrateNetwork sNet) {
-		metric = new TotalCommunicationCostMetricD(sNet);
+		metric = new TotalCommunicationCostObjectiveC(sNet);
 	}
 
 	/*
 	 * Positive tests
 	 */
-
-	@Override
-	@Test
-	public void testEmbeddingSameHost() {
-		createSubstrateNetwork();
-		setupEmbeddingSameHost();
-		final SubstrateNetwork sNet = (SubstrateNetwork) facade.getNetworkById("sub");
-		setMetric(sNet);
-
-		assertEquals(Double.POSITIVE_INFINITY, metric.getValue());
-	}
 
 	@Override
 	@Test
@@ -43,7 +32,7 @@ public class TotalCommunicationCostMetricDTest extends ATotalCommunicationCostMe
 		final SubstrateNetwork sNet = (SubstrateNetwork) facade.getNetworkById("sub");
 		setMetric(sNet);
 
-		assertEquals(13.333, metric.getValue(), 0.01);
+		assertEquals(2 * 2 * 3 + 3, metric.getValue());
 	}
 
 }

--- a/test.suite/src/test/metrics/TotalCommunicationCostObjectiveDTest.java
+++ b/test.suite/src/test/metrics/TotalCommunicationCostObjectiveDTest.java
@@ -4,25 +4,36 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import metrics.embedding.TotalCommunicationCostMetricC;
+import metrics.embedding.TotalCommunicationCostObjectiveD;
 import model.SubstrateNetwork;
 
 /**
  * Test class for the metric of total communication cost as implemented in
- * {@link TotalCommunicationCostMetricC}.
+ * {@link TotalCommunicationCostObjectiveD}.
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class TotalCommunicationCostMetricCTest extends ATotalCommunicationCostMetricTest {
+public class TotalCommunicationCostObjectiveDTest extends ATotalCommunicationCostMetricTest {
 
 	@Override
 	protected void setMetric(final SubstrateNetwork sNet) {
-		metric = new TotalCommunicationCostMetricC(sNet);
+		metric = new TotalCommunicationCostObjectiveD(sNet);
 	}
 
 	/*
 	 * Positive tests
 	 */
+
+	@Override
+	@Test
+	public void testEmbeddingSameHost() {
+		createSubstrateNetwork();
+		setupEmbeddingSameHost();
+		final SubstrateNetwork sNet = (SubstrateNetwork) facade.getNetworkById("sub");
+		setMetric(sNet);
+
+		assertEquals(Double.POSITIVE_INFINITY, metric.getValue());
+	}
 
 	@Override
 	@Test
@@ -32,7 +43,7 @@ public class TotalCommunicationCostMetricCTest extends ATotalCommunicationCostMe
 		final SubstrateNetwork sNet = (SubstrateNetwork) facade.getNetworkById("sub");
 		setMetric(sNet);
 
-		assertEquals(2 * 2 * 3 + 3, metric.getValue());
+		assertEquals(13.333, metric.getValue(), 0.01);
 	}
 
 }

--- a/vne.algorithms/src/algorithms/AlgorithmConfig.java
+++ b/vne.algorithms/src/algorithms/AlgorithmConfig.java
@@ -21,8 +21,8 @@ public class AlgorithmConfig {
 		TOTAL_PATH_COST, // [1]
 		TOTAL_COMMUNICATION_COST_A, // [2]
 		TOTAL_COMMUNICATION_COST_B, // [3,4] (One hop = 1 cost, no node costs)
-		TOTAL_COMMUNICATION_COST_C, // [5] (One hop = 1 cost, with node costs)
-		TOTAL_COMMUNICATION_COST_D, // [6] (One hop = 1 cost, with node costs)
+		TOTAL_COMMUNICATION_OBJECTIVE_C, // [5] (One hop = 1 cost, with node costs)
+		TOTAL_COMMUNICATION_OBJECTIVE_D, // [6] (One hop = 1 cost, with node costs)
 		TOTAL_TAF_COMMUNICATION_COST; // [7]
 
 		/*
@@ -80,7 +80,7 @@ public class AlgorithmConfig {
 	 * Objective goal for the algorithms {@link VneIlpPathAlgorithm} and
 	 * {@link VnePmMdvneAlgorithm}.
 	 */
-	public static Objective obj = Objective.TOTAL_COMMUNICATION_COST_C;
+	public static Objective obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 
 	/**
 	 * Embedding mechanism for the {@link VnePmMdvneAlgorithm}

--- a/vne.algorithms/src/algorithms/ilp/VneFakeIlpAlgorithm.java
+++ b/vne.algorithms/src/algorithms/ilp/VneFakeIlpAlgorithm.java
@@ -767,9 +767,9 @@ public class VneFakeIlpAlgorithm extends AbstractAlgorithm {
 		case TOTAL_COMMUNICATION_COST_B:
 			return CostUtility.getTotalCommunicationCostNodeAB();
 		case TOTAL_COMMUNICATION_COST_C:
-			return CostUtility.getTotalCommunicationCostNodeC(virt, sub);
+			return CostUtility.getTotalCommunicationCostObjectiveNodeC(virt, sub);
 		case TOTAL_COMMUNICATION_COST_D:
-			return CostUtility.getTotalCommunicationCostNodeD(virt, sub);
+			return CostUtility.getTotalCommunicationCostObjectiveNodeD(virt, sub);
 		default:
 			throw new UnsupportedOperationException();
 		}

--- a/vne.algorithms/src/algorithms/ilp/VneFakeIlpAlgorithm.java
+++ b/vne.algorithms/src/algorithms/ilp/VneFakeIlpAlgorithm.java
@@ -766,9 +766,9 @@ public class VneFakeIlpAlgorithm extends AbstractAlgorithm {
 			return CostUtility.getTotalCommunicationCostNodeAB();
 		case TOTAL_COMMUNICATION_COST_B:
 			return CostUtility.getTotalCommunicationCostNodeAB();
-		case TOTAL_COMMUNICATION_COST_C:
+		case TOTAL_COMMUNICATION_OBJECTIVE_C:
 			return CostUtility.getTotalCommunicationCostObjectiveNodeC(virt, sub);
-		case TOTAL_COMMUNICATION_COST_D:
+		case TOTAL_COMMUNICATION_OBJECTIVE_D:
 			return CostUtility.getTotalCommunicationCostObjectiveNodeD(virt, sub);
 		default:
 			throw new UnsupportedOperationException();
@@ -783,9 +783,9 @@ public class VneFakeIlpAlgorithm extends AbstractAlgorithm {
 			return CostUtility.getTotalCommunicationCostLinkA(virt, sub);
 		case TOTAL_COMMUNICATION_COST_B:
 			return CostUtility.getTotalCommunicationCostLinkBCD(virt, sub);
-		case TOTAL_COMMUNICATION_COST_C:
+		case TOTAL_COMMUNICATION_OBJECTIVE_C:
 			return CostUtility.getTotalCommunicationCostLinkBCD(virt, sub);
-		case TOTAL_COMMUNICATION_COST_D:
+		case TOTAL_COMMUNICATION_OBJECTIVE_D:
 			return CostUtility.getTotalCommunicationCostLinkBCD(virt, sub);
 		default:
 			throw new UnsupportedOperationException();

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithm.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithm.java
@@ -742,9 +742,9 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 		case TOTAL_COMMUNICATION_COST_B:
 			return CostUtility.getTotalCommunicationCostNodeAB();
 		case TOTAL_COMMUNICATION_COST_C:
-			return CostUtility.getTotalCommunicationCostNodeC(virt, sub);
+			return CostUtility.getTotalCommunicationCostObjectiveNodeC(virt, sub);
 		case TOTAL_COMMUNICATION_COST_D:
-			return CostUtility.getTotalCommunicationCostNodeD(virt, sub);
+			return CostUtility.getTotalCommunicationCostObjectiveNodeD(virt, sub);
 		default:
 			throw new UnsupportedOperationException();
 		}

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithm.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithm.java
@@ -741,9 +741,9 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 			return CostUtility.getTotalCommunicationCostNodeAB();
 		case TOTAL_COMMUNICATION_COST_B:
 			return CostUtility.getTotalCommunicationCostNodeAB();
-		case TOTAL_COMMUNICATION_COST_C:
+		case TOTAL_COMMUNICATION_OBJECTIVE_C:
 			return CostUtility.getTotalCommunicationCostObjectiveNodeC(virt, sub);
-		case TOTAL_COMMUNICATION_COST_D:
+		case TOTAL_COMMUNICATION_OBJECTIVE_D:
 			return CostUtility.getTotalCommunicationCostObjectiveNodeD(virt, sub);
 		default:
 			throw new UnsupportedOperationException();
@@ -758,9 +758,9 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 			return CostUtility.getTotalCommunicationCostLinkA(virt, sub);
 		case TOTAL_COMMUNICATION_COST_B:
 			return CostUtility.getTotalCommunicationCostLinkBCD(virt, sub);
-		case TOTAL_COMMUNICATION_COST_C:
+		case TOTAL_COMMUNICATION_OBJECTIVE_C:
 			return CostUtility.getTotalCommunicationCostLinkBCD(virt, sub);
-		case TOTAL_COMMUNICATION_COST_D:
+		case TOTAL_COMMUNICATION_OBJECTIVE_D:
 			return CostUtility.getTotalCommunicationCostLinkBCD(virt, sub);
 		default:
 			throw new UnsupportedOperationException();

--- a/vne.scenarios/src/scenario/util/CsvUtil.java
+++ b/vne.scenarios/src/scenario/util/CsvUtil.java
@@ -21,6 +21,8 @@ import metrics.embedding.AveragePathLengthMetric;
 import metrics.embedding.OperatingCostMetric;
 import metrics.embedding.TotalCommunicationCostMetricA;
 import metrics.embedding.TotalCommunicationCostMetricB;
+import metrics.embedding.TotalCommunicationCostMetricC;
+import metrics.embedding.TotalCommunicationCostMetricD;
 import metrics.embedding.TotalCommunicationCostObjectiveC;
 import metrics.embedding.TotalCommunicationCostObjectiveD;
 import metrics.embedding.TotalPathCostMetric;
@@ -49,16 +51,35 @@ public class CsvUtil {
 	/**
 	 * CSV file header format for normal runs (simulation).
 	 */
-	private static CSVFormat formatNormal = CSVFormat.DEFAULT.withHeader("counter", "timestamp", "lastVNR", "time_pm",
-			"time_ilp", "time_deploy", "time_rest", "accepted_vnrs", "total_path_cost", "average_path_length",
-			"total_communication_cost_a", "total_communication_cost_b", "total_communication_objective_c",
-			"total_communication_objective_d", "total_taf_communication_cost", "operation_cost", "memory_start",
-			"memory_ilp", "memory_end", "memory_pid_max");
+	private static CSVFormat formatNormal = CSVFormat.DEFAULT.withHeader(//
+			"counter", //
+			"timestamp", //
+			"lastVNR", //
+			"time_pm", //
+			"time_ilp", //
+			"time_deploy", //
+			"time_rest", //
+			"accepted_vnrs", //
+			"total_path_cost", //
+			"average_path_length", //
+			"total_communication_cost_a", //
+			"total_communication_cost_b", //
+			"total_communication_cost_c", //
+			"total_communication_cost_d", //
+			"total_communication_objective_c", //
+			"total_communication_objective_d", //
+			"total_taf_communication_cost", //
+			"operation_cost", //
+			"memory_start", //
+			"memory_ilp", //
+			"memory_end", //
+			"memory_pid_max");
 
 	/**
 	 * CSV file header format for mean and standard derivation (after simulation).
 	 */
-	private static CSVFormat formatStats = CSVFormat.DEFAULT.withHeader("counter", //
+	private static CSVFormat formatStats = CSVFormat.DEFAULT.withHeader(//
+			"counter", //
 			"time_pm", "time_pm_stddev", //
 			"time_ilp", "time_ilp_stddev", //
 			"time_deploy", "time_deploy_stddev", //
@@ -68,6 +89,8 @@ public class CsvUtil {
 			"average_path_length", "average_path_length_stddev", //
 			"total_communication_cost_a", "total_communication_cost_a_stddev", //
 			"total_communication_cost_b", "total_communication_cost_b_stddev", //
+			"total_communication_cost_c", "total_communication_cost_c_stddev", //
+			"total_communication_cost_d", "total_communication_cost_d_stddev", //
 			"total_communication_objective_c", "total_communication_objective_c_stddev", //
 			"total_communication_objective_d", "total_communication_objective_d_stddev", //
 			"total_taf_communication_cost", "total_taf_communication_cost_stddev", //
@@ -112,16 +135,18 @@ public class CsvUtil {
 		content[9] = String.valueOf(new AveragePathLengthMetric(sNet).getValue());
 		content[10] = String.valueOf(new TotalCommunicationCostMetricA(sNet).getValue());
 		content[11] = String.valueOf(new TotalCommunicationCostMetricB(sNet).getValue());
-		content[12] = String.valueOf(new TotalCommunicationCostObjectiveC(sNet).getValue());
-		content[13] = String.valueOf(new TotalCommunicationCostObjectiveD(sNet).getValue());
-		content[14] = String.valueOf(new TotalTafCommunicationCostMetric(sNet).getValue());
-		content[15] = String.valueOf(new OperatingCostMetric(sNet).getValue());
-		content[16] = String.valueOf(GlobalMetricsManager.getMemory().getValue(0)); // Memory start
+		content[12] = String.valueOf(new TotalCommunicationCostMetricC(sNet).getValue());
+		content[13] = String.valueOf(new TotalCommunicationCostMetricD(sNet).getValue());
+		content[14] = String.valueOf(new TotalCommunicationCostObjectiveC(sNet).getValue());
+		content[15] = String.valueOf(new TotalCommunicationCostObjectiveD(sNet).getValue());
+		content[16] = String.valueOf(new TotalTafCommunicationCostMetric(sNet).getValue());
+		content[17] = String.valueOf(new OperatingCostMetric(sNet).getValue());
+		content[18] = String.valueOf(GlobalMetricsManager.getMemory().getValue(0)); // Memory start
 																					// execute
-		content[17] = String.valueOf(GlobalMetricsManager.getMemory().getValue(1)); // Memory before ILP
-		content[18] = String.valueOf(GlobalMetricsManager.getMemory().getValue(2)); // Memory end
+		content[19] = String.valueOf(GlobalMetricsManager.getMemory().getValue(1)); // Memory before ILP
+		content[20] = String.valueOf(GlobalMetricsManager.getMemory().getValue(2)); // Memory end
 																					// execute
-		content[19] = String.valueOf(GlobalMetricsManager.getMemoryPid()); // Maximum amount of memory
+		content[21] = String.valueOf(GlobalMetricsManager.getMemoryPid()); // Maximum amount of memory
 																			// (RAM) consumed
 		writeCsvLine(csvPath, formatNormal, content);
 	}
@@ -141,14 +166,14 @@ public class CsvUtil {
 			final CSVParser parser = new CSVParser(new FileReader(csvPath), formatNormal);
 			final List<CSVRecord> recs = parser.getRecords();
 			for (int i = 1; i < recs.size(); i++) {
-				final Double[] val = new Double[18];
+				final Double[] val = new Double[22];
 				final CSVRecord rec = recs.get(i);
-				for (int j = 3; j <= 19; j++) {
+				for (int j = 3; j <= 23; j++) {
 					val[j - 3] = Double.valueOf(rec.get(j));
 				}
 
 				// Sum time metrics up
-				val[17] = val[0] // time_pm
+				val[21] = val[0] // time_pm
 						+ val[1] // time_ilp
 						+ val[2] // time_deploy
 						+ val[3]; // time_rest

--- a/vne.scenarios/src/scenario/util/CsvUtil.java
+++ b/vne.scenarios/src/scenario/util/CsvUtil.java
@@ -21,8 +21,8 @@ import metrics.embedding.AveragePathLengthMetric;
 import metrics.embedding.OperatingCostMetric;
 import metrics.embedding.TotalCommunicationCostMetricA;
 import metrics.embedding.TotalCommunicationCostMetricB;
-import metrics.embedding.TotalCommunicationCostMetricC;
-import metrics.embedding.TotalCommunicationCostMetricD;
+import metrics.embedding.TotalCommunicationCostObjectiveC;
+import metrics.embedding.TotalCommunicationCostObjectiveD;
 import metrics.embedding.TotalPathCostMetric;
 import metrics.embedding.TotalTafCommunicationCostMetric;
 import metrics.manager.GlobalMetricsManager;
@@ -51,8 +51,8 @@ public class CsvUtil {
 	 */
 	private static CSVFormat formatNormal = CSVFormat.DEFAULT.withHeader("counter", "timestamp", "lastVNR", "time_pm",
 			"time_ilp", "time_deploy", "time_rest", "accepted_vnrs", "total_path_cost", "average_path_length",
-			"total_communication_cost_a", "total_communication_cost_b", "total_communication_cost_c",
-			"total_communication_cost_d", "total_taf_communication_cost", "operation_cost", "memory_start",
+			"total_communication_cost_a", "total_communication_cost_b", "total_communication_objective_c",
+			"total_communication_objective_d", "total_taf_communication_cost", "operation_cost", "memory_start",
 			"memory_ilp", "memory_end", "memory_pid_max");
 
 	/**
@@ -68,8 +68,8 @@ public class CsvUtil {
 			"average_path_length", "average_path_length_stddev", //
 			"total_communication_cost_a", "total_communication_cost_a_stddev", //
 			"total_communication_cost_b", "total_communication_cost_b_stddev", //
-			"total_communication_cost_c", "total_communication_cost_c_stddev", //
-			"total_communication_cost_d", "total_communication_cost_d_stddev", //
+			"total_communication_objective_c", "total_communication_objective_c_stddev", //
+			"total_communication_objective_d", "total_communication_objective_d_stddev", //
 			"total_taf_communication_cost", "total_taf_communication_cost_stddev", //
 			"operation_cost", "operation_cost_stddev", //
 			"memory_start", "memory_start_stddev", //
@@ -112,8 +112,8 @@ public class CsvUtil {
 		content[9] = String.valueOf(new AveragePathLengthMetric(sNet).getValue());
 		content[10] = String.valueOf(new TotalCommunicationCostMetricA(sNet).getValue());
 		content[11] = String.valueOf(new TotalCommunicationCostMetricB(sNet).getValue());
-		content[12] = String.valueOf(new TotalCommunicationCostMetricC(sNet).getValue());
-		content[13] = String.valueOf(new TotalCommunicationCostMetricD(sNet).getValue());
+		content[12] = String.valueOf(new TotalCommunicationCostObjectiveC(sNet).getValue());
+		content[13] = String.valueOf(new TotalCommunicationCostObjectiveD(sNet).getValue());
 		content[14] = String.valueOf(new TotalTafCommunicationCostMetric(sNet).getValue());
 		content[15] = String.valueOf(new OperatingCostMetric(sNet).getValue());
 		content[16] = String.valueOf(GlobalMetricsManager.getMemory().getValue(0)); // Memory start

--- a/vne.scenarios/src/scenarios/load/DissScenarioLoad.java
+++ b/vne.scenarios/src/scenarios/load/DissScenarioLoad.java
@@ -36,6 +36,8 @@ import metrics.embedding.AveragePathLengthMetric;
 import metrics.embedding.OperatingCostMetric;
 import metrics.embedding.TotalCommunicationCostMetricA;
 import metrics.embedding.TotalCommunicationCostMetricB;
+import metrics.embedding.TotalCommunicationCostMetricC;
+import metrics.embedding.TotalCommunicationCostMetricD;
 import metrics.embedding.TotalCommunicationCostObjectiveC;
 import metrics.embedding.TotalCommunicationCostObjectiveD;
 import metrics.embedding.TotalPathCostMetric;
@@ -284,10 +286,10 @@ public class DissScenarioLoad {
 			AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
 			break;
 		case "total-comm-c":
-			AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_C;
+			AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 			break;
 		case "total-comm-d":
-			AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_D;
+			AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_D;
 			break;
 		case "total-taf-comm":
 			AlgorithmConfig.obj = Objective.TOTAL_TAF_COMMUNICATION_COST;
@@ -430,6 +432,8 @@ public class DissScenarioLoad {
 		System.out.println("=> Average path length: " + new AveragePathLengthMetric(sNet).getValue());
 		System.out.println("=> Total communication cost A: " + new TotalCommunicationCostMetricA(sNet).getValue());
 		System.out.println("=> Total communication cost B: " + new TotalCommunicationCostMetricB(sNet).getValue());
+		System.out.println("=> Total communication cost C: " + new TotalCommunicationCostMetricC(sNet).getValue());
+		System.out.println("=> Total communication cost D: " + new TotalCommunicationCostMetricD(sNet).getValue());
 		System.out.println(
 				"=> Total communication objective C: " + new TotalCommunicationCostObjectiveC(sNet).getValue());
 		System.out.println(

--- a/vne.scenarios/src/scenarios/load/DissScenarioLoad.java
+++ b/vne.scenarios/src/scenarios/load/DissScenarioLoad.java
@@ -36,8 +36,8 @@ import metrics.embedding.AveragePathLengthMetric;
 import metrics.embedding.OperatingCostMetric;
 import metrics.embedding.TotalCommunicationCostMetricA;
 import metrics.embedding.TotalCommunicationCostMetricB;
-import metrics.embedding.TotalCommunicationCostMetricC;
-import metrics.embedding.TotalCommunicationCostMetricD;
+import metrics.embedding.TotalCommunicationCostObjectiveC;
+import metrics.embedding.TotalCommunicationCostObjectiveD;
 import metrics.embedding.TotalPathCostMetric;
 import metrics.embedding.TotalTafCommunicationCostMetric;
 import metrics.manager.GlobalMetricsManager;
@@ -430,8 +430,10 @@ public class DissScenarioLoad {
 		System.out.println("=> Average path length: " + new AveragePathLengthMetric(sNet).getValue());
 		System.out.println("=> Total communication cost A: " + new TotalCommunicationCostMetricA(sNet).getValue());
 		System.out.println("=> Total communication cost B: " + new TotalCommunicationCostMetricB(sNet).getValue());
-		System.out.println("=> Total communication cost C: " + new TotalCommunicationCostMetricC(sNet).getValue());
-		System.out.println("=> Total communication cost D: " + new TotalCommunicationCostMetricD(sNet).getValue());
+		System.out.println(
+				"=> Total communication objective C: " + new TotalCommunicationCostObjectiveC(sNet).getValue());
+		System.out.println(
+				"=> Total communication objective D: " + new TotalCommunicationCostObjectiveD(sNet).getValue());
 		System.out.println("=> Total TAF communication cost: " + new TotalTafCommunicationCostMetric(sNet).getValue());
 		System.out.println("=> Operation cost: " + new OperatingCostMetric(sNet).getValue());
 


### PR DESCRIPTION
There was confusion around the *Total Communication Cost C* metric. This PR introduces a correct TCCC metric and renames the old implementation to *Total Communication Objective C* (because we still need it for the algorithm objectives).