### PR TITLE
Adds a test for the model load bug: missing clear of path lookup ds

### DIFF
--- a/test.suite/resources/pathLoadModel_noPaths.xmi
+++ b/test.suite/resources/pathLoadModel_noPaths.xmi
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<network.model:Root
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:network.model="platform:/resource/network.model/model/Model.ecore">
+  <networks
+      xsi:type="network.model:SubstrateNetwork"
+      name="net">
+    <nodes xsi:type="network.model:SubstrateSwitch"
+        name="sw"
+        outgoingLinks="//@networks.0/@links.2 //@networks.0/@links.3"
+        incomingLinks="//@networks.0/@links.0 //@networks.0/@links.1"/>
+    <nodes xsi:type="network.model:SubstrateServer"
+        name="srv1"
+        depth="1"
+        outgoingLinks="//@networks.0/@links.0"
+        incomingLinks="//@networks.0/@links.2"/>
+    <nodes xsi:type="network.model:SubstrateServer"
+        name="srv2"
+        depth="1"
+        outgoingLinks="//@networks.0/@links.1"
+        incomingLinks="//@networks.0/@links.3"/>
+    <links xsi:type="network.model:SubstrateLink"
+        name="ln1"
+        bandwidth="1"
+        source="//@networks.0/@nodes.1"
+        target="//@networks.0/@nodes.0"
+        residualBandwidth="1"/>
+    <links xsi:type="network.model:SubstrateLink"
+        name="ln2"
+        bandwidth="2"
+        source="//@networks.0/@nodes.2"
+        target="//@networks.0/@nodes.0"
+        residualBandwidth="2"/>
+    <links xsi:type="network.model:SubstrateLink"
+        name="ln3"
+        bandwidth="1"
+        source="//@networks.0/@nodes.0"
+        target="//@networks.0/@nodes.1"
+        residualBandwidth="1"/>
+    <links xsi:type="network.model:SubstrateLink"
+        name="ln4"
+        bandwidth="2"
+        source="//@networks.0/@nodes.0"
+        target="//@networks.0/@nodes.2"
+        residualBandwidth="2"/>
+  </networks>
+</network.model:Root>

--- a/test.suite/src/test/model/ModelFacadePathLoadTest.java
+++ b/test.suite/src/test/model/ModelFacadePathLoadTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +27,7 @@ import model.SubstratePath;
 public class ModelFacadePathLoadTest {
 
 	private final String referenceModelFile = "resources/pathLoadModel.xmi";
+	private final String referenceModelFileWoPaths = "resources/pathLoadModel_noPaths.xmi";
 
 	@BeforeEach
 	public void resetModel() {
@@ -130,6 +132,34 @@ public class ModelFacadePathLoadTest {
 
 		assertNotNull(ModelFacade.getInstance().getPathsFromSourceToTarget(getNode("sw"), getNode("srv2")));
 		assertEquals(1, ModelFacade.getInstance().getPathsFromSourceToTarget(getNode("sw"), getNode("srv2")).size());
+	}
+
+	@Test
+	public void testPathLookupDataClear() {
+		// Load a model file which contains paths
+		ModelFacade.getInstance().loadModel(referenceModelFile);
+
+		// Check existing of paths beforehand
+		assertNotNull(ModelFacade.getInstance().getAllPathsOfNetwork("net"));
+		assertFalse(ModelFacade.getInstance().getAllPathsOfNetwork("net").isEmpty());
+		assertNotNull(ModelFacade.getInstance().getPathFromSourceToTarget(getNode("srv1"), getNode("srv2")));
+		assertEquals(1, ModelFacade.getInstance().getPathsFromSourceToTarget(getNode("srv1"), getNode("srv2")).size());
+
+		// Save old nodes for later look ups
+		final SubstrateNode srv1old = getNode("srv1");
+		final SubstrateNode srv2old = getNode("srv2");
+
+		// Now load a model without any paths
+		ModelFacade.getInstance().loadModel(referenceModelFileWoPaths);
+
+		// Check non-existance of any paths (method will use the lookup data structure)
+		assertNotNull(ModelFacade.getInstance().getAllPathsOfNetwork("net"));
+		// Newer nodes must not be contained
+		assertTrue(ModelFacade.getInstance().getAllPathsOfNetwork("net").isEmpty());
+		assertNull(ModelFacade.getInstance().getPathFromSourceToTarget(getNode("srv1"), getNode("srv2")));
+
+		// Old nodes must also not be contained
+		assertNull(ModelFacade.getInstance().getPathFromSourceToTarget(srv1old, srv2old));
 	}
 
 	/**


### PR DESCRIPTION
Tests this bugfix: https://github.com/Echtzeitsysteme/gips-examples/pull/34