### PR TITLE
use instances of VNE algorithms

### DIFF
--- a/examples/src/examples/algorithms/SimpleVneExample.java
+++ b/examples/src/examples/algorithms/SimpleVneExample.java
@@ -36,7 +36,8 @@ public class SimpleVneExample {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final SimpleVne svne = new SimpleVne(sNet, Set.of(vNet));
+		final SimpleVne svne = new SimpleVne();
+		svne.prepare(sNet, Set.of(vNet));
 		svne.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/TafAlgorithmInterRackExample.java
+++ b/examples/src/examples/algorithms/TafAlgorithmInterRackExample.java
@@ -50,7 +50,8 @@ public class TafAlgorithmInterRackExample {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		taf.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/TafAlgorithmIntraRackOneTierExample.java
+++ b/examples/src/examples/algorithms/TafAlgorithmIntraRackOneTierExample.java
@@ -45,7 +45,8 @@ public class TafAlgorithmIntraRackOneTierExample {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		taf.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/TafAlgorithmIntraRackOneTierLargerExample.java
+++ b/examples/src/examples/algorithms/TafAlgorithmIntraRackOneTierLargerExample.java
@@ -45,7 +45,8 @@ public class TafAlgorithmIntraRackOneTierLargerExample {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt_1");
 
 		// Create and execute algorithm
-		TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		taf.execute();
 
 		virtualConfig = new OneTierConfig(2, 1, false, 1, 1, 1, 5);
@@ -55,7 +56,8 @@ public class TafAlgorithmIntraRackOneTierLargerExample {
 		final VirtualNetwork vNet2 = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt_2");
 
 		// Create and execute algorithm
-		taf = new TafAlgorithm(sNet, Set.of(vNet2));
+		taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet2));
 		taf.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/TafAlgorithmIntraRackTwoTierExample.java
+++ b/examples/src/examples/algorithms/TafAlgorithmIntraRackTwoTierExample.java
@@ -50,7 +50,8 @@ public class TafAlgorithmIntraRackTwoTierExample {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		taf.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/TafAlgorithmIntraRackTwoTierLargerExample.java
+++ b/examples/src/examples/algorithms/TafAlgorithmIntraRackTwoTierLargerExample.java
@@ -50,7 +50,8 @@ public class TafAlgorithmIntraRackTwoTierLargerExample {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		taf.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/TafAlgorithmIntraServerExample.java
+++ b/examples/src/examples/algorithms/TafAlgorithmIntraServerExample.java
@@ -45,7 +45,8 @@ public class TafAlgorithmIntraServerExample {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		taf.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/TafAlgorithmTwoVnsExample.java
+++ b/examples/src/examples/algorithms/TafAlgorithmTwoVnsExample.java
@@ -51,7 +51,8 @@ public class TafAlgorithmTwoVnsExample {
 			virtGen.createNetwork("virt_" + i, true);
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt_" + i);
 			// Create and execute algorithm
-			final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+			final TafAlgorithm taf = new TafAlgorithm();
+			taf.prepare(sNet, Set.of(vNet));
 			taf.execute();
 		}
 

--- a/examples/src/examples/algorithms/TafAlgorithmTwoVnsLargerExample.java
+++ b/examples/src/examples/algorithms/TafAlgorithmTwoVnsLargerExample.java
@@ -51,7 +51,8 @@ public class TafAlgorithmTwoVnsLargerExample {
 			virtGen.createNetwork("virt_" + i, true);
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt_" + i);
 			// Create and execute algorithm
-			final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+			final TafAlgorithm taf = new TafAlgorithm();
+			taf.prepare(sNet, Set.of(vNet));
 			taf.execute();
 		}
 

--- a/examples/src/examples/algorithms/VneFakeIlpAlgorithmExampleMedium.java
+++ b/examples/src/examples/algorithms/VneFakeIlpAlgorithmExampleMedium.java
@@ -59,7 +59,8 @@ public class VneFakeIlpAlgorithmExampleMedium {
 
 			// Create and execute algorithm
 			System.out.println("=> Embedding virtual network #" + i);
-			final VneFakeIlpAlgorithm algo = VneFakeIlpAlgorithm.prepare(sNet, Set.of(vNet));
+			final VneFakeIlpAlgorithm algo = new VneFakeIlpAlgorithm();
+			algo.prepare(sNet, Set.of(vNet));
 			algo.execute();
 		}
 

--- a/examples/src/examples/algorithms/VneFakeIlpAlgorithmExampleOneServer.java
+++ b/examples/src/examples/algorithms/VneFakeIlpAlgorithmExampleOneServer.java
@@ -50,7 +50,8 @@ public class VneFakeIlpAlgorithmExampleOneServer {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneFakeIlpBatchAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/VneFakeIlpAlgorithmExampleSmall.java
+++ b/examples/src/examples/algorithms/VneFakeIlpAlgorithmExampleSmall.java
@@ -52,7 +52,8 @@ public class VneFakeIlpAlgorithmExampleSmall {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneFakeIlpBatchAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VneFakeIlpBatchAlgorithmExampleOneTier.java
+++ b/examples/src/examples/algorithms/VneFakeIlpBatchAlgorithmExampleOneTier.java
@@ -48,7 +48,8 @@ public class VneFakeIlpBatchAlgorithmExampleOneTier {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneFakeIlpBatchAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/VneFakeIlpBatchAlgorithmExampleSmallDuplicate.java
+++ b/examples/src/examples/algorithms/VneFakeIlpBatchAlgorithmExampleSmallDuplicate.java
@@ -52,9 +52,11 @@ public class VneFakeIlpBatchAlgorithmExampleSmallDuplicate {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		AbstractAlgorithm algo = VneFakeIlpBatchAlgorithm.prepare(sNet, Set.of(vNet));
+		AbstractAlgorithm algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
-		algo = VneFakeIlpBatchAlgorithm.prepare(sNet, Set.of(vNet));
+		algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VneFakeIlpBatchAlgorithmExampleTwoTier.java
+++ b/examples/src/examples/algorithms/VneFakeIlpBatchAlgorithmExampleTwoTier.java
@@ -56,7 +56,8 @@ public class VneFakeIlpBatchAlgorithmExampleTwoTier {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneFakeIlpBatchAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/VneFakeIlpBatchAlgorithmExampleTwoTierMultipleVns.java
+++ b/examples/src/examples/algorithms/VneFakeIlpBatchAlgorithmExampleTwoTierMultipleVns.java
@@ -66,7 +66,8 @@ public class VneFakeIlpBatchAlgorithmExampleTwoTierMultipleVns {
 		});
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneFakeIlpBatchAlgorithm.prepare(sNet, virtNets);
+		final AbstractAlgorithm algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, virtNets);
 		algo.execute();
 
 		// Save model to file

--- a/examples/src/examples/algorithms/VneGipsAlgorithmExampleLarge.java
+++ b/examples/src/examples/algorithms/VneGipsAlgorithmExampleLarge.java
@@ -55,7 +55,8 @@ public class VneGipsAlgorithmExampleLarge {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneGipsAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VneGipsAlgorithmExampleSmall.java
+++ b/examples/src/examples/algorithms/VneGipsAlgorithmExampleSmall.java
@@ -55,7 +55,8 @@ public class VneGipsAlgorithmExampleSmall {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneGipsAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VneGipsAlgorithmExampleTiny.java
+++ b/examples/src/examples/algorithms/VneGipsAlgorithmExampleTiny.java
@@ -48,7 +48,8 @@ public class VneGipsAlgorithmExampleTiny {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneGipsAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VneGipsSeqAlgorithmExampleLarge.java
+++ b/examples/src/examples/algorithms/VneGipsSeqAlgorithmExampleLarge.java
@@ -55,7 +55,8 @@ public class VneGipsSeqAlgorithmExampleLarge {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneGipsSeqAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VneGipsSeqAlgorithmExampleTiny.java
+++ b/examples/src/examples/algorithms/VneGipsSeqAlgorithmExampleTiny.java
@@ -49,7 +49,8 @@ public class VneGipsSeqAlgorithmExampleTiny {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneGipsSeqAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 //		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VneGipsSeqAlgorithmExampleTwoNodesOneLinkOntoPath.java
+++ b/examples/src/examples/algorithms/VneGipsSeqAlgorithmExampleTwoNodesOneLinkOntoPath.java
@@ -55,7 +55,8 @@ public class VneGipsSeqAlgorithmExampleTwoNodesOneLinkOntoPath {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneGipsSeqAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 //		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VneGipsSeqAlgorithmExampleTwoNodesOneLinkOntoServer.java
+++ b/examples/src/examples/algorithms/VneGipsSeqAlgorithmExampleTwoNodesOneLinkOntoServer.java
@@ -49,7 +49,8 @@ public class VneGipsSeqAlgorithmExampleTwoNodesOneLinkOntoServer {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = VneGipsSeqAlgorithm.prepare(sNet, Set.of(vNet));
+		final AbstractAlgorithm algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 //		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleDualRead.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleDualRead.java
@@ -40,7 +40,8 @@ public class VnePmMdvneAlgorithmExampleDualRead {
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById(vNetId);
 
 			// Create and execute algorithm
-			final AbstractAlgorithm algo = VnePmMdvneAlgorithm.prepare(sNet, Set.of(vNet));
+			final AbstractAlgorithm algo = new VnePmMdvneAlgorithm();
+			algo.prepare(sNet, Set.of(vNet));
 			algo.execute();
 		}
 

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleFatTree.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleFatTree.java
@@ -64,7 +64,8 @@ public class VnePmMdvneAlgorithmExampleFatTree {
 
 			// Create and execute algorithm
 			System.out.println("=> Embedding virtual network #" + i);
-			final VnePmMdvneAlgorithm algo = VnePmMdvneAlgorithm.prepare(sNet, Set.of(vNet));
+			final VnePmMdvneAlgorithm algo = new VnePmMdvneAlgorithm();
+			algo.prepare(sNet, Set.of(vNet));
 			algo.execute();
 			// algo.dispose();
 		}

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleMedium.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleMedium.java
@@ -56,7 +56,8 @@ public class VnePmMdvneAlgorithmExampleMedium {
 
 			// Create and execute algorithm
 			System.out.println("=> Embedding virtual network #" + i);
-			final VnePmMdvneAlgorithm algo = VnePmMdvneAlgorithm.prepare(sNet, Set.of(vNet));
+			final VnePmMdvneAlgorithm algo = new VnePmMdvneAlgorithm();
+			algo.prepare(sNet, Set.of(vNet));
 			algo.execute();
 		}
 

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleRead.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleRead.java
@@ -50,7 +50,8 @@ public class VnePmMdvneAlgorithmExampleRead {
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById(vNetId);
 
 			// Create and execute algorithm
-			final AbstractAlgorithm algo = VnePmMdvneAlgorithm.prepare(sNet, Set.of(vNet));
+			final AbstractAlgorithm algo = new VnePmMdvneAlgorithm();
+			algo.prepare(sNet, Set.of(vNet));
 			algo.execute();
 		}
 

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleRejectUpdate.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleRejectUpdate.java
@@ -48,7 +48,8 @@ public class VnePmMdvneAlgorithmExampleRejectUpdate {
 
 		SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
-		AbstractAlgorithm algo = VnePmMdvneAlgorithmMigration.prepare(sNet, Set.of(vNet));
+		AbstractAlgorithm algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		/*
@@ -57,7 +58,8 @@ public class VnePmMdvneAlgorithmExampleRejectUpdate {
 		virtGen.createNetwork("virt2", true);
 		sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt2");
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, Set.of(vNet));
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		/*
@@ -66,7 +68,8 @@ public class VnePmMdvneAlgorithmExampleRejectUpdate {
 		virtGen.createNetwork("virt3", true);
 		sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt3");
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, Set.of(vNet));
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		// Remove second virtual network to get a scenario in which two substrate
@@ -84,7 +87,8 @@ public class VnePmMdvneAlgorithmExampleRejectUpdate {
 		virtGen.createNetwork("virt4", true);
 		sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt4");
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, Set.of(vNet));
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleRepairModelNetwork.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleRepairModelNetwork.java
@@ -62,7 +62,8 @@ public class VnePmMdvneAlgorithmExampleRepairModelNetwork {
 
 			// Create and execute algorithm
 			System.out.println("=> Embedding virtual network #" + i);
-			final VnePmMdvneAlgorithm algo = VnePmMdvneAlgorithm.prepare(sNet, Set.of(vNet));
+			final VnePmMdvneAlgorithm algo = new VnePmMdvneAlgorithm();
+			algo.prepare(sNet, Set.of(vNet));
 			algo.execute();
 		}
 

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleRepairModelServer.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleRepairModelServer.java
@@ -65,7 +65,8 @@ public class VnePmMdvneAlgorithmExampleRepairModelServer {
 
 			// Create and execute algorithm
 			System.out.println("=> Embedding virtual network #" + i);
-			final VnePmMdvneAlgorithm algo = VnePmMdvneAlgorithm.prepare(sNet, Set.of(vNet));
+			final VnePmMdvneAlgorithm algo = new VnePmMdvneAlgorithm();
+			algo.prepare(sNet, Set.of(vNet));
 			algo.execute();
 		}
 

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleSmall.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleSmall.java
@@ -51,7 +51,8 @@ public class VnePmMdvneAlgorithmExampleSmall {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		// Create and execute algorithm
-		final VnePmMdvneAlgorithm algo = VnePmMdvneAlgorithm.prepare(sNet, Set.of(vNet));
+		final VnePmMdvneAlgorithm algo = new VnePmMdvneAlgorithm();
+		algo.prepare(sNet, Set.of(vNet));
 		algo.execute();
 
 		GlobalMetricsManager.stopRuntime();

--- a/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleTwoTier.java
+++ b/examples/src/examples/algorithms/VnePmMdvneAlgorithmExampleTwoTier.java
@@ -65,7 +65,8 @@ public class VnePmMdvneAlgorithmExampleTwoTier {
 
 			// Create and execute algorithm
 			System.out.println("=> Embedding virtual network #" + i);
-			final VnePmMdvneAlgorithm algo = VnePmMdvneAlgorithm.prepare(sNet, Set.of(vNet));
+			final VnePmMdvneAlgorithm algo = new VnePmMdvneAlgorithm();
+			algo.prepare(sNet, Set.of(vNet));
 			algo.execute();
 		}
 

--- a/network.metrics/src/metrics/memory/MemoryPidMetric.java
+++ b/network.metrics/src/metrics/memory/MemoryPidMetric.java
@@ -39,6 +39,12 @@ public class MemoryPidMetric implements IMetric {
 			return;
 		}
 		final File file = new File("/proc/" + getPid() + "/status");
+		if (!file.exists()) {
+			System.err.println("Proc file for MemoryPidMetric is not available!");
+			this.memory = -1;
+			return;
+		}
+
 		final List<String> lines = Unix4j.grep("VmHWM", file).toStringList();
 		final String memComplex = lines.get(0);
 		final String mem = memComplex.replaceAll("\\D+", "");

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalCommunicationCostATest.java
@@ -40,7 +40,8 @@ public class VneFakeIlpAlgorithmTotalCommunicationCostATest extends AAlgorithmMu
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	/**

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalCommunicationCostBTest.java
@@ -40,7 +40,8 @@ public class VneFakeIlpAlgorithmTotalCommunicationCostBTest extends AAlgorithmMu
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	/**

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalCommunicationObjectiveCTest.java
@@ -41,7 +41,8 @@ public class VneFakeIlpAlgorithmTotalCommunicationObjectiveCTest extends AAlgori
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	/**

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpAlgorithmTotalPathCostTest.java
@@ -31,7 +31,8 @@ public class VneFakeIlpAlgorithmTotalPathCostTest extends AAlgorithmMultipleVnsT
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmMigrationTest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmMigrationTest.java
@@ -54,7 +54,8 @@ public class VneFakeIlpBatchAlgorithmMigrationTest extends AAlgorithmTest {
 		// Total communication cost A is needed for this test
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpBatchAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@Test

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalCommunicationCostATest.java
@@ -22,7 +22,8 @@ public class VneFakeIlpBatchAlgorithmTotalCommunicationCostATest
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpBatchAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalCommunicationCostBTest.java
@@ -22,7 +22,8 @@ public class VneFakeIlpBatchAlgorithmTotalCommunicationCostBTest
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpBatchAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalCommunicationObjectiveCTest.java
@@ -25,7 +25,8 @@ public class VneFakeIlpBatchAlgorithmTotalCommunicationObjectiveCTest
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpBatchAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	/**

--- a/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/fakeilp/VneFakeIlpBatchAlgorithmTotalPathCostTest.java
@@ -32,7 +32,8 @@ public class VneFakeIlpBatchAlgorithmTotalPathCostTest extends VneFakeIlpAlgorit
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		algo = VneFakeIlpBatchAlgorithm.prepare(sNet, vNets);
+		algo = new VneFakeIlpBatchAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmMultipleSnetsTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmMultipleSnetsTest.java
@@ -44,7 +44,8 @@ public class VneGipsAlgorithmMultipleSnetsTest extends AAlgorithmTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmObjectiveTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmObjectiveTest.java
@@ -43,7 +43,8 @@ public class VneGipsAlgorithmObjectiveTest extends AAlgorithmTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmPathBandwidthBugTest.java
@@ -24,7 +24,8 @@ public class VneGipsAlgorithmPathBandwidthBugTest extends AVneAlgorithmPathBandw
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmRejectionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmRejectionTest.java
@@ -48,7 +48,8 @@ public class VneGipsAlgorithmRejectionTest extends AAlgorithmTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmSimpleTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmSimpleTest.java
@@ -38,7 +38,8 @@ public class VneGipsAlgorithmSimpleTest extends AAlgorithmTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmTotalCommunicationObjectiveCTest.java
@@ -35,7 +35,8 @@ public class VneGipsAlgorithmTotalCommunicationObjectiveCTest extends AAlgorithm
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmVnetSetExceptionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/VneGipsAlgorithmVnetSetExceptionTest.java
@@ -37,7 +37,8 @@ public class VneGipsAlgorithmVnetSetExceptionTest extends AAlgorithmTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmConfigTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmConfigTest.java
@@ -34,7 +34,8 @@ public class VneGipsBwIgnoreAlgorithmConfigTest extends AAlgorithmTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VneGipsBwIgnoreAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsBwIgnoreAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmMultipleSnetsTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmMultipleSnetsTest.java
@@ -26,7 +26,8 @@ public class VneGipsBwIgnoreAlgorithmMultipleSnetsTest extends VneGipsAlgorithmM
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsBwIgnoreAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsBwIgnoreAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmRejectionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmRejectionTest.java
@@ -40,7 +40,8 @@ public class VneGipsBwIgnoreAlgorithmRejectionTest extends VneGipsAlgorithmRejec
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsBwIgnoreAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsBwIgnoreAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmSimpleTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmSimpleTest.java
@@ -26,7 +26,8 @@ public class VneGipsBwIgnoreAlgorithmSimpleTest extends VneGipsAlgorithmSimpleTe
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsBwIgnoreAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsBwIgnoreAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@Override

--- a/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmTotalCommunicationObjectiveCTest.java
@@ -26,7 +26,8 @@ public class VneGipsBwIgnoreAlgorithmTotalCommunicationObjectiveCTest
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsBwIgnoreAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsBwIgnoreAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmVnetSetExceptionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/bwignore/VneGipsBwIgnoreAlgorithmVnetSetExceptionTest.java
@@ -37,7 +37,8 @@ public class VneGipsBwIgnoreAlgorithmVnetSetExceptionTest extends AAlgorithmTest
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsBwIgnoreAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsBwIgnoreAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmMultipleSnetsTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmMultipleSnetsTest.java
@@ -26,7 +26,8 @@ public class VneGipsHeapAlgorithmMultipleSnetsTest extends VneGipsAlgorithmMulti
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsHeapAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsHeapAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmPreferenceTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmPreferenceTest.java
@@ -41,7 +41,8 @@ public class VneGipsHeapAlgorithmPreferenceTest extends AAlgorithmTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsHeapAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsHeapAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmRejectionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmRejectionTest.java
@@ -34,7 +34,8 @@ public class VneGipsHeapAlgorithmRejectionTest extends VneGipsAlgorithmRejection
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsHeapAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsHeapAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmSimpleTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmSimpleTest.java
@@ -34,7 +34,8 @@ public class VneGipsHeapAlgorithmSimpleTest extends VneGipsAlgorithmSimpleTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsHeapAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsHeapAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmVnetSetExceptionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsHeapAlgorithmVnetSetExceptionTest.java
@@ -37,7 +37,8 @@ public class VneGipsHeapAlgorithmVnetSetExceptionTest extends AAlgorithmTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsHeapAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsHeapAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsSeqAlgorithmPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/heap/VneGipsSeqAlgorithmPathBandwidthBugTest.java
@@ -24,7 +24,8 @@ public class VneGipsSeqAlgorithmPathBandwidthBugTest extends AVneAlgorithmPathBa
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsHeapAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsHeapAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/lookahead/AVneGipsLookaheadAlgorithmTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/lookahead/AVneGipsLookaheadAlgorithmTest.java
@@ -41,7 +41,9 @@ public class AVneGipsLookaheadAlgorithmTest extends AAlgorithmTest {
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsLookaheadAlgorithm.prepare(sNet, vNets, vNetId);
+		algo = new VneGipsLookaheadAlgorithm();
+		algo.prepare(sNet, vNets);
+		((VneGipsLookaheadAlgorithm) algo).setVNetId(vNetId);
 	}
 
 	@Override

--- a/test.suite.iflye/src/test/algorithms/gips/lookahead/VneGipsLookaheadAlgorithmMultipleSnetsTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/lookahead/VneGipsLookaheadAlgorithmMultipleSnetsTest.java
@@ -24,7 +24,8 @@ public class VneGipsLookaheadAlgorithmMultipleSnetsTest extends VneGipsAlgorithm
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsLookaheadAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsLookaheadAlgorithm();
+		algo.prepare(sNet, vNets);
 		((VneGipsLookaheadAlgorithm) algo).setVNetId("virt");
 	}
 

--- a/test.suite.iflye/src/test/algorithms/gips/lookahead/VneGipsLookaheadAlgorithmSimpleTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/lookahead/VneGipsLookaheadAlgorithmSimpleTest.java
@@ -29,7 +29,9 @@ public class VneGipsLookaheadAlgorithmSimpleTest extends VneGipsAlgorithmSimpleT
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsLookaheadAlgorithm.prepare(sNet, vNets, vNetId);
+		algo = new VneGipsLookaheadAlgorithm();
+		algo.prepare(sNet, vNets);
+		((VneGipsLookaheadAlgorithm) algo).setVNetId(vNetId);
 	}
 
 	@Override

--- a/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmMigIsNecessaryTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmMigIsNecessaryTest.java
@@ -40,7 +40,8 @@ public class VneGipsMigrationAlgorithmMigIsNecessaryTest extends AAlgorithmTest 
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsMigrationAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsMigrationAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmMultipleSnetsTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmMultipleSnetsTest.java
@@ -26,13 +26,14 @@ public class VneGipsMigrationAlgorithmMultipleSnetsTest extends VneGipsAlgorithm
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsMigrationAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsMigrationAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach
 	public void resetAlgo() {
 		facade.resetAll();
-		((VneGipsMigrationAlgorithm) algo).dispose();
+		algo.dispose();
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmPathBandwidthBugTest.java
@@ -24,14 +24,15 @@ public class VneGipsMigrationAlgorithmPathBandwidthBugTest extends AVneAlgorithm
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsMigrationAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsMigrationAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach
 	public void resetAlgo() {
 		facade.resetAll();
 		if (algo != null) {
-			((VneGipsMigrationAlgorithm) algo).dispose();
+			algo.dispose();
 		}
 	}
 

--- a/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmRejectionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmRejectionTest.java
@@ -24,14 +24,15 @@ public class VneGipsMigrationAlgorithmRejectionTest extends VneGipsAlgorithmReje
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsMigrationAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsMigrationAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@Override
 	@AfterEach
 	public void resetAlgo() {
 		facade.resetAll();
-		((VneGipsMigrationAlgorithm) algo).dispose();
+		algo.dispose();
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmSimpleTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmSimpleTest.java
@@ -24,14 +24,15 @@ public class VneGipsMigrationAlgorithmSimpleTest extends VneGipsAlgorithmSimpleT
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsMigrationAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsMigrationAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@Override
 	@AfterEach
 	public void resetAlgo() {
 		facade.resetAll();
-		((VneGipsMigrationAlgorithm) algo).dispose();
+		algo.dispose();
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmVnetSetExceptionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/migration/VneGipsMigrationAlgorithmVnetSetExceptionTest.java
@@ -37,14 +37,15 @@ public class VneGipsMigrationAlgorithmVnetSetExceptionTest extends AAlgorithmTes
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsMigrationAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsMigrationAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach
 	public void resetAlgo() {
 		facade.resetAll();
 		if (algo != null) {
-			((VneGipsMigrationAlgorithm) algo).dispose();
+			algo.dispose();
 		}
 	}
 

--- a/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmMultipleSnetsTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmMultipleSnetsTest.java
@@ -26,13 +26,14 @@ public class VneGipsSeqAlgorithmMultipleSnetsTest extends VneGipsAlgorithmMultip
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
 		ModelFacadeConfig.IGNORE_BW = true;
-		algo = VneGipsSeqAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach
 	public void resetAlgo() {
 		facade.resetAll();
-		((VneGipsSeqAlgorithm) algo).dispose();
+		algo.dispose();
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmObjectiveTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmObjectiveTest.java
@@ -36,7 +36,8 @@ public class VneGipsSeqAlgorithmObjectiveTest extends VneGipsAlgorithmObjectiveT
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsSeqAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmPathBandwidthBugTest.java
@@ -24,7 +24,8 @@ public class VneGipsSeqAlgorithmPathBandwidthBugTest extends AVneAlgorithmPathBa
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsSeqAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmRejectionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmRejectionTest.java
@@ -34,7 +34,8 @@ public class VneGipsSeqAlgorithmRejectionTest extends VneGipsAlgorithmRejectionT
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsSeqAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmSimpleTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmSimpleTest.java
@@ -34,7 +34,8 @@ public class VneGipsSeqAlgorithmSimpleTest extends VneGipsAlgorithmSimpleTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsSeqAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmTotalCommunicationObjectiveCTest.java
@@ -23,7 +23,8 @@ public class VneGipsSeqAlgorithmTotalCommunicationObjectiveCTest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsSeqAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmVnetSetExceptionTest.java
+++ b/test.suite.iflye/src/test/algorithms/gips/seq/VneGipsSeqAlgorithmVnetSetExceptionTest.java
@@ -37,7 +37,8 @@ public class VneGipsSeqAlgorithmVnetSetExceptionTest extends AAlgorithmTest {
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VneGipsSeqAlgorithm.prepare(sNet, vNets);
+		algo = new VneGipsSeqAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/heuristics/TafAlgorithmFatTreeTest.java
+++ b/test.suite.iflye/src/test/algorithms/heuristics/TafAlgorithmFatTreeTest.java
@@ -31,7 +31,8 @@ public class TafAlgorithmFatTreeTest extends AAlgorithmTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = new TafAlgorithm(sNet, vNets);
+		algo = new TafAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@BeforeEach
@@ -65,7 +66,8 @@ public class TafAlgorithmFatTreeTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		assertTrue(taf.execute());
 	}
 
@@ -86,7 +88,8 @@ public class TafAlgorithmFatTreeTest extends AAlgorithmTest {
 			final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt" + i);
 
-			final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+			final TafAlgorithm taf = new TafAlgorithm();
+			taf.prepare(sNet, Set.of(vNet));
 			assertTrue(taf.execute());
 		}
 	}
@@ -108,7 +111,8 @@ public class TafAlgorithmFatTreeTest extends AAlgorithmTest {
 			final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt" + i);
 
-			final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+			final TafAlgorithm taf = new TafAlgorithm();
+			taf.prepare(sNet, Set.of(vNet));
 			assertTrue(taf.execute());
 		}
 	}
@@ -128,7 +132,8 @@ public class TafAlgorithmFatTreeTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		assertTrue(taf.execute());
 	}
 
@@ -147,7 +152,8 @@ public class TafAlgorithmFatTreeTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		assertTrue(taf.execute());
 	}
 
@@ -166,7 +172,8 @@ public class TafAlgorithmFatTreeTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		assertTrue(taf.execute());
 	}
 
@@ -190,7 +197,8 @@ public class TafAlgorithmFatTreeTest extends AAlgorithmTest {
 			final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt" + i);
 
-			final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+			final TafAlgorithm taf = new TafAlgorithm();
+			taf.prepare(sNet, Set.of(vNet));
 
 			if (i < 16) {
 				assertTrue(taf.execute());

--- a/test.suite.iflye/src/test/algorithms/heuristics/TafAlgorithmTest.java
+++ b/test.suite.iflye/src/test/algorithms/heuristics/TafAlgorithmTest.java
@@ -34,7 +34,8 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = new TafAlgorithm(sNet, vNets);
+		algo = new TafAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@BeforeEach
@@ -64,7 +65,8 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		assertTrue(taf.execute());
 
 		// Test all vServer hosts
@@ -94,7 +96,8 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		assertTrue(taf.execute());
 
 		// Test switch placement
@@ -144,7 +147,8 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		assertTrue(taf.execute());
 
 		// Test switch placement
@@ -205,7 +209,8 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 		assertTrue(taf.execute());
 
 		// Test switch placement
@@ -271,7 +276,7 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(UnsupportedOperationException.class, () -> {
-			new TafAlgorithm(sNet, Set.of(vNet));
+			new TafAlgorithm().prepare(sNet, Set.of(vNet));
 		});
 	}
 
@@ -287,7 +292,7 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(UnsupportedOperationException.class, () -> {
-			new TafAlgorithm(sNet, Set.of(vNet));
+			new TafAlgorithm().prepare(sNet, Set.of(vNet));
 		});
 	}
 
@@ -304,7 +309,7 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(UnsupportedOperationException.class, () -> {
-			new TafAlgorithm(sNet, Set.of(vNet));
+			new TafAlgorithm().prepare(sNet, Set.of(vNet));
 		});
 	}
 
@@ -316,7 +321,7 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(UnsupportedOperationException.class, () -> {
-			new TafAlgorithm(sNet, Set.of(vNet));
+			new TafAlgorithm().prepare(sNet, Set.of(vNet));
 		});
 	}
 
@@ -330,7 +335,7 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(UnsupportedOperationException.class, () -> {
-			new TafAlgorithm(sNet, Set.of(vNet));
+			new TafAlgorithm().prepare(sNet, Set.of(vNet));
 		});
 	}
 
@@ -344,7 +349,8 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final TafAlgorithm taf = new TafAlgorithm(sNet, Set.of(vNet));
+		final TafAlgorithm taf = new TafAlgorithm();
+		taf.prepare(sNet, Set.of(vNet));
 
 		// Embedding should not be possible, because a split of one VM to embed it on
 		// two substrate
@@ -363,7 +369,8 @@ public class TafAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(IllegalArgumentException.class, () -> {
-			new TafAlgorithm(sNet, Set.of(vNet, vNet));
+			new TafAlgorithm();
+			algo.prepare(sNet, Set.of(vNet, vNet));
 		});
 	}
 

--- a/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmPathBandwidthBugTest.java
@@ -23,7 +23,8 @@ public class VnePmMdvneAlgorithmPathBandwidthBugTest extends AVneAlgorithmPathBa
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmRepairModelNetworkTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmRepairModelNetworkTest.java
@@ -30,7 +30,8 @@ public class VnePmMdvneAlgorithmRepairModelNetworkTest extends AAlgorithmTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmRepairModelServerTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmRepairModelServerTest.java
@@ -33,7 +33,8 @@ public class VnePmMdvneAlgorithmRepairModelServerTest extends AAlgorithmTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalCommunicationCostATest.java
@@ -31,7 +31,8 @@ public class VnePmMdvneAlgorithmTotalCommunicationCostATest extends AAlgorithmMu
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalCommunicationCostBTest.java
@@ -31,7 +31,8 @@ public class VnePmMdvneAlgorithmTotalCommunicationCostBTest extends AAlgorithmMu
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest.java
@@ -32,7 +32,8 @@ public class VnePmMdvneAlgorithmTotalCommunicationObjectiveCTest extends AAlgori
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/VnePmMdvneAlgorithmTotalPathCostTest.java
@@ -39,7 +39,8 @@ public class VnePmMdvneAlgorithmTotalPathCostTest extends AAlgorithmMultipleVnsT
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationPathBandwidthBugTest.java
@@ -23,7 +23,8 @@ public class VnePmMdvneAlgorithmMigrationPathBandwidthBugTest extends AVneAlgori
 		// The algorithm is only able to use the total communication objective C because
 		// it is hard-coded in GIPSL
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationRepairModelNetworkTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationRepairModelNetworkTest.java
@@ -19,7 +19,8 @@ public class VnePmMdvneAlgorithmMigrationRepairModelNetworkTest extends VnePmMdv
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationRepairModelServerTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationRepairModelServerTest.java
@@ -19,7 +19,8 @@ public class VnePmMdvneAlgorithmMigrationRepairModelServerTest extends VnePmMdvn
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTest.java
@@ -37,7 +37,8 @@ public class VnePmMdvneAlgorithmMigrationTest extends AAlgorithmTest {
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, vNets);
 	}
 
 	@BeforeEach

--- a/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalCommunicationCostATest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmMigrationTotalCommunicationCostATest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalCommunicationCostBTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmMigrationTotalCommunicationCostBTest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalCommunicationObjectiveCTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmMigrationTotalCommunicationObjectiveCTest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/migration/VnePmMdvneAlgorithmMigrationTotalPathCostTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmMigrationTotalPathCostTest extends VnePmMdvneAlg
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
-		algo = VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmMigration();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesAPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesAPathBandwidthBugTest.java
@@ -19,7 +19,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesAPathBandwidthBugTest extends
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesA();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesARepairModelNetworkTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesARepairModelNetworkTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesARepairModelNetworkTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesA();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesARepairModelServerTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesARepairModelServerTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesARepairModelServerTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesA();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationCostATest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationCostATest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesA();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationCostBTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationCostBTest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesA();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationObjectiveCTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesATotalCommunicationObjectiveC
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesA();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesATotalPathCostTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesATotalPathCostTest extends Vn
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesA();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBPathBandwidthBugTest.java
@@ -19,7 +19,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesBPathBandwidthBugTest extends
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesB();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBRepairModelNetworkTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBRepairModelNetworkTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesBRepairModelNetworkTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBRepairModelServerTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBRepairModelServerTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesBRepairModelServerTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationCostATest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationCostATest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationCostBTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationCostBTest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationObjectiveCTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesBTotalCommunicationObjectiveC
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineThreeStagesBTotalPathCostTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineThreeStagesBTotalPathCostTest extends Vn
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
-		algo = VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineThreeStagesB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackAPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackAPathBandwidthBugTest.java
@@ -19,7 +19,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackAPathBandwidthBugTest exten
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackA();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackARepairModelNetworkTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackARepairModelNetworkTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackARepairModelNetworkTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackA();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackARepairModelServerTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackARepairModelServerTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackARepairModelServerTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackA();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationCostATest.java
@@ -24,7 +24,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationCostATes
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackA();
+		algo.prepare(sNet, vNets);
 	}
 
 	@Override

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationCostBTest.java
@@ -24,7 +24,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationCostBTes
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackA();
+		algo.prepare(sNet, vNets);
 	}
 
 	@Override

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationObjectiveCTest.java
@@ -24,7 +24,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackATotalCommunicationObjectiv
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackA();
+		algo.prepare(sNet, vNets);
 	}
 
 	@Override

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackATotalPathCostTest.java
@@ -30,7 +30,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackATotalPathCostTest extends 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackA();
+		algo.prepare(sNet, vNets);
 	}
 
 	@Override

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBPathBandwidthBugTest.java
@@ -19,7 +19,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackBPathBandwidthBugTest exten
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackB();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBRepairModelNetworkTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBRepairModelNetworkTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackBRepairModelNetworkTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBRepairModelServerTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBRepairModelServerTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackBRepairModelServerTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationCostATest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationCostATes
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationCostBTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationCostBTes
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationObjectiveCTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalCommunicationObjectiv
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalPathCostTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackBTotalPathCostTest extends 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesRackB();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetPathBandwidthBugTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetPathBandwidthBugTest.java
@@ -18,7 +18,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesVnetPathBandwidthBugTest extend
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesVnet();
+		algo.prepare(sNet, vNets);
 	}
 
 	@AfterEach

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetRepairModelNetworkTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetRepairModelNetworkTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesVnetRepairModelNetworkTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesVnet();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetRepairModelServerTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetRepairModelServerTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesVnetRepairModelServerTest
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesVnet();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationCostATest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationCostATest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationCostATest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_A;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesVnet();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationCostBTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationCostBTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationCostBTest
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_COST_B;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesVnet();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationObjectiveCTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationObjectiveCTest.java
@@ -21,7 +21,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalCommunicationObjective
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_COMMUNICATION_OBJECTIVE_C;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesVnet();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalPathCostTest.java
+++ b/test.suite.iflye/src/test/algorithms/pm/pipeline/VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalPathCostTest.java
@@ -20,7 +20,8 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesVnetTotalPathCostTest extends V
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		AlgorithmConfig.obj = Objective.TOTAL_PATH_COST;
-		algo = VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
+		algo = new VnePmMdvneAlgorithmPipelineTwoStagesVnet();
+		algo.prepare(sNet, vNets);
 	}
 
 }

--- a/test.suite.iflye/src/test/algorithms/random/RandomAlgorithmFatTreeTest.java
+++ b/test.suite.iflye/src/test/algorithms/random/RandomAlgorithmFatTreeTest.java
@@ -29,7 +29,8 @@ public class RandomAlgorithmFatTreeTest extends AAlgorithmTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = new RandomVneAlgorithm(sNet, vNets);
+		algo = new RandomVneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@BeforeEach
@@ -63,7 +64,8 @@ public class RandomAlgorithmFatTreeTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertTrue(randomVne.execute());
 	}
 
@@ -84,7 +86,8 @@ public class RandomAlgorithmFatTreeTest extends AAlgorithmTest {
 			final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt" + i);
 
-			final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+			final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+			randomVne.prepare(sNet, Set.of(vNet));
 			assertTrue(randomVne.execute());
 		}
 	}
@@ -106,7 +109,8 @@ public class RandomAlgorithmFatTreeTest extends AAlgorithmTest {
 			final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt" + i);
 
-			final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+			final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+			randomVne.prepare(sNet, Set.of(vNet));
 			assertTrue(randomVne.execute());
 		}
 	}
@@ -126,7 +130,8 @@ public class RandomAlgorithmFatTreeTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertTrue(randomVne.execute());
 	}
 
@@ -145,7 +150,8 @@ public class RandomAlgorithmFatTreeTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertTrue(randomVne.execute());
 	}
 
@@ -164,7 +170,8 @@ public class RandomAlgorithmFatTreeTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertTrue(randomVne.execute());
 	}
 
@@ -188,7 +195,8 @@ public class RandomAlgorithmFatTreeTest extends AAlgorithmTest {
 			final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt" + i);
 
-			final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+			final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+			randomVne.prepare(sNet, Set.of(vNet));
 
 			if (i < 16) {
 				assertTrue(randomVne.execute());

--- a/test.suite.iflye/src/test/algorithms/random/RandomAlgorithmGiveupTest.java
+++ b/test.suite.iflye/src/test/algorithms/random/RandomAlgorithmGiveupTest.java
@@ -33,7 +33,8 @@ public class RandomAlgorithmGiveupTest extends AAlgorithmTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = new RandomVneAlgorithm(sNet, vNets);
+		algo = new RandomVneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@BeforeEach
@@ -68,7 +69,8 @@ public class RandomAlgorithmGiveupTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertFalse(randomVne.execute());
 
 		// Test all vServer hosts

--- a/test.suite.iflye/src/test/algorithms/random/RandomAlgorithmTest.java
+++ b/test.suite.iflye/src/test/algorithms/random/RandomAlgorithmTest.java
@@ -32,7 +32,8 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 
 	@Override
 	public void initAlgo(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		algo = new RandomVneAlgorithm(sNet, vNets);
+		algo = new RandomVneAlgorithm();
+		algo.prepare(sNet, vNets);
 	}
 
 	@BeforeEach
@@ -66,7 +67,8 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertTrue(randomVne.execute());
 
 		// Test all vServer hosts
@@ -96,7 +98,8 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertTrue(randomVne.execute());
 
 		// Test switch placement
@@ -138,7 +141,8 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertTrue(randomVne.execute());
 
 		// Test switch placement
@@ -180,7 +184,8 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 		assertTrue(randomVne.execute());
 
 		// Test switch placement
@@ -234,7 +239,7 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(UnsupportedOperationException.class, () -> {
-			new RandomVneAlgorithm(sNet, Set.of(vNet));
+			new RandomVneAlgorithm().prepare(sNet, Set.of(vNet));
 		});
 	}
 
@@ -246,7 +251,7 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(UnsupportedOperationException.class, () -> {
-			new RandomVneAlgorithm(sNet, Set.of(vNet));
+			new RandomVneAlgorithm().prepare(sNet, Set.of(vNet));
 		});
 	}
 
@@ -260,7 +265,7 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(UnsupportedOperationException.class, () -> {
-			new RandomVneAlgorithm(sNet, Set.of(vNet));
+			new RandomVneAlgorithm().prepare(sNet, Set.of(vNet));
 		});
 	}
 
@@ -274,7 +279,8 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final SubstrateNetwork sNet = (SubstrateNetwork) ModelFacade.getInstance().getNetworkById("sub");
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
-		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm(sNet, Set.of(vNet));
+		final RandomVneAlgorithm randomVne = new RandomVneAlgorithm();
+		randomVne.prepare(sNet, Set.of(vNet));
 
 		// Embedding should not be possible, because a split of one VM to embed it on
 		// two substrate servers is not possible although the total amount of resources
@@ -291,7 +297,7 @@ public class RandomAlgorithmTest extends AAlgorithmTest {
 		final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById("virt");
 
 		assertThrows(IllegalArgumentException.class, () -> {
-			new RandomVneAlgorithm(sNet, Set.of(vNet, vNet));
+			new RandomVneAlgorithm().prepare(sNet, Set.of(vNet, vNet));
 		});
 	}
 

--- a/test.suite.iflye/src/test/utils/GenericTestUtils.java
+++ b/test.suite.iflye/src/test/utils/GenericTestUtils.java
@@ -28,7 +28,8 @@ public class GenericTestUtils {
 	public static void vneFakeIlpEmbedding(SubstrateNetwork sNet, Set<VirtualNetwork> vNets) {
 		final Embedding oldEmbeddingMechanism = AlgorithmConfig.emb;
 		AlgorithmConfig.emb = Embedding.MANUAL;
-		final AbstractAlgorithm algo = VneFakeIlpAlgorithm.prepare(sNet, vNets);
+		final AbstractAlgorithm algo = new VneFakeIlpAlgorithm();
+		algo.prepare(sNet, vNets);
 		assertTrue(algo.execute());
 		AlgorithmConfig.emb = oldEmbeddingMechanism;
 	}

--- a/vne.algorithms/META-INF/MANIFEST.MF
+++ b/vne.algorithms/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.emf.ecore,
  network.model.rules.rackb,
  network.model.rules.vnet,
  network.metrics,
- org.emoflon.smartemf
+ org.emoflon.smartemf,
+ org.emoflon.gips.core
 Export-Package: algorithms,
  algorithms.gips,
  algorithms.heuristics,

--- a/vne.algorithms/src/algorithms/AbstractAlgorithm.java
+++ b/vne.algorithms/src/algorithms/AbstractAlgorithm.java
@@ -2,6 +2,7 @@ package algorithms;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
 
 import facade.ModelFacade;
@@ -14,12 +15,12 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public abstract class AbstractAlgorithm {
+public abstract class AbstractAlgorithm implements Algorithm {
 
 	/**
 	 * ModelFacade instance.
 	 */
-	public static ModelFacade facade = ModelFacade.getInstance();
+	protected ModelFacade modelFacade;
 
 	/**
 	 * The substrate network (model).
@@ -36,16 +37,35 @@ public abstract class AbstractAlgorithm {
 	 *
 	 * @return True if embedding process was successful.
 	 */
+	@Override
 	public abstract boolean execute();
 
 	/**
-	 * Initializes a new abstract algorithm with a given substrate and given virtual
-	 * networks.
+	 * Initializes a new abstract algorithm
+	 */
+	public AbstractAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Initializes a new abstract algorithm
 	 *
+	 * @param modelFacade The ModelFacade to use
+	 */
+	public AbstractAlgorithm(final ModelFacade modelFacade) {
+		Objects.requireNonNull(modelFacade);
+
+		this.modelFacade = modelFacade;
+	}
+
+	/**
+	 * Prepare the algorithm for execution
+	 * 
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets A set of virtual networks to work with.
 	 */
-	public AbstractAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		if (sNet == null || vNets == null) {
 			throw new IllegalArgumentException("One of the provided network objects was null!");
 		}
@@ -59,6 +79,10 @@ public abstract class AbstractAlgorithm {
 		this.vNets.addAll(vNets);
 	}
 
+	@Override
+	public void dispose() {
+	}
+
 	/**
 	 * Returns the first virtual network from this super type.
 	 *
@@ -67,6 +91,15 @@ public abstract class AbstractAlgorithm {
 	protected VirtualNetwork getFirstVnet() {
 		final Iterator<VirtualNetwork> it = vNets.iterator();
 		return it.next();
+	}
+
+	/**
+	 * Returns the currently used ModelFacade instance.
+	 * 
+	 * @return The used ModelFacade instance.
+	 */
+	public ModelFacade getModelFacade() {
+		return this.modelFacade;
 	}
 
 }

--- a/vne.algorithms/src/algorithms/Algorithm.java
+++ b/vne.algorithms/src/algorithms/Algorithm.java
@@ -1,0 +1,35 @@
+package algorithms;
+
+import java.util.Set;
+
+import model.SubstrateNetwork;
+import model.VirtualNetwork;
+
+/**
+ * This interface defines the basic structure and interaction of an algorithm.
+ *
+ * @author Janik Stracke {@literal <janik.stracke@stud.tu-darmstadt.de>}
+ */
+public interface Algorithm {
+
+	/**
+	 * Execution method that starts the algorithm itself.
+	 *
+	 * @return True if embedding process was successful.
+	 */
+	public abstract boolean execute();
+
+	/**
+	 * Prepare the algorithm for execution
+	 * 
+	 * @param sNet  Substrate network to work with.
+	 * @param vNets A set of virtual networks to work with.
+	 */
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets);
+
+	/**
+	 * Dispose and terminate used resources.
+	 */
+	public abstract void dispose();
+
+}

--- a/vne.algorithms/src/algorithms/AlgorithmPipeline.java
+++ b/vne.algorithms/src/algorithms/AlgorithmPipeline.java
@@ -1,11 +1,8 @@
 package algorithms;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import facade.ModelFacade;
 import model.SubstrateNetwork;
 import model.VirtualNetwork;
 
@@ -14,60 +11,19 @@ import model.VirtualNetwork;
  *
  * @author Janik Stracke {@literal <janik.stracke@stud.tu-darmstadt.de>}
  */
-public abstract class AlgorithmPipeline extends AbstractAlgorithm {
+public interface AlgorithmPipeline extends Algorithm {
 
 	/**
 	 * List of algorithms that are part of the pipeline.
 	 */
-	protected final List<AbstractAlgorithm> pipeline = new ArrayList<>();
-
-	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 */
-	public AlgorithmPipeline() {
-		this(ModelFacade.getInstance());
-	}
-
-	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param pipeline List of algorithms that are part of the pipeline.
-	 */
-	public AlgorithmPipeline(final Collection<AbstractAlgorithm> pipeline) {
-		this(ModelFacade.getInstance(), pipeline);
-	}
-
-	/**
-	 * Constructor.
-	 */
-	public AlgorithmPipeline(final ModelFacade modelFacade) {
-		this(modelFacade, List.of());
-	}
-
-	/**
-	 * Constructor that gets the ModelFacade and the algorithms that are part of the
-	 * pipeline.
-	 *
-	 * @param modelFacade ModelFacade instance
-	 * @param pipeline    List of algorithms that are part of the pipeline.
-	 */
-	public AlgorithmPipeline(final ModelFacade modelFacade, final Collection<AbstractAlgorithm> pipeline) {
-		super(modelFacade);
-
-		this.pipeline.addAll(pipeline);
-	}
+	public List<AbstractAlgorithm> getPipeline();
 
 	/**
 	 * Prepare the algorithm for execution
 	 */
 	@Override
-	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super.prepare(sNet, vNets);
-
-		for (AbstractAlgorithm algo : pipeline) {
+	default public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+		for (AbstractAlgorithm algo : getPipeline()) {
 			algo.prepare(sNet, vNets);
 		}
 	}
@@ -76,10 +32,8 @@ public abstract class AlgorithmPipeline extends AbstractAlgorithm {
 	 * Resets the ILP solver and the pattern matcher.
 	 */
 	@Override
-	public void dispose() {
-		super.dispose();
-
-		for (AbstractAlgorithm algo : pipeline) {
+	default public void dispose() {
+		for (AbstractAlgorithm algo : getPipeline()) {
 			algo.dispose();
 		}
 	}
@@ -88,8 +42,8 @@ public abstract class AlgorithmPipeline extends AbstractAlgorithm {
 	 * Execute the pipeline.
 	 */
 	@Override
-	public boolean execute() {
-		for (AbstractAlgorithm algo : pipeline) {
+	default public boolean execute() {
+		for (AbstractAlgorithm algo : getPipeline()) {
 			if (algo.execute()) {
 				return true;
 			}

--- a/vne.algorithms/src/algorithms/AlgorithmPipeline.java
+++ b/vne.algorithms/src/algorithms/AlgorithmPipeline.java
@@ -1,0 +1,101 @@
+package algorithms;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import facade.ModelFacade;
+import model.SubstrateNetwork;
+import model.VirtualNetwork;
+
+/**
+ * Implementation of a generic algorithm pipeline
+ *
+ * @author Janik Stracke {@literal <janik.stracke@stud.tu-darmstadt.de>}
+ */
+public abstract class AlgorithmPipeline extends AbstractAlgorithm {
+
+	/**
+	 * List of algorithms that are part of the pipeline.
+	 */
+	protected final List<AbstractAlgorithm> pipeline = new ArrayList<>();
+
+	/**
+	 * Constructor that gets the substrate as well as the virtual network.
+	 *
+	 * @param sNet  Substrate network to work with.
+	 * @param vNets Set of virtual networks to work with.
+	 */
+	public AlgorithmPipeline() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor that gets the substrate as well as the virtual network.
+	 *
+	 * @param pipeline List of algorithms that are part of the pipeline.
+	 */
+	public AlgorithmPipeline(final Collection<AbstractAlgorithm> pipeline) {
+		this(ModelFacade.getInstance(), pipeline);
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public AlgorithmPipeline(final ModelFacade modelFacade) {
+		this(modelFacade, List.of());
+	}
+
+	/**
+	 * Constructor that gets the ModelFacade and the algorithms that are part of the
+	 * pipeline.
+	 *
+	 * @param modelFacade ModelFacade instance
+	 * @param pipeline    List of algorithms that are part of the pipeline.
+	 */
+	public AlgorithmPipeline(final ModelFacade modelFacade, final Collection<AbstractAlgorithm> pipeline) {
+		super(modelFacade);
+
+		this.pipeline.addAll(pipeline);
+	}
+
+	/**
+	 * Prepare the algorithm for execution
+	 */
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+		super.prepare(sNet, vNets);
+
+		for (AbstractAlgorithm algo : pipeline) {
+			algo.prepare(sNet, vNets);
+		}
+	}
+
+	/**
+	 * Resets the ILP solver and the pattern matcher.
+	 */
+	@Override
+	public void dispose() {
+		super.dispose();
+
+		for (AbstractAlgorithm algo : pipeline) {
+			algo.dispose();
+		}
+	}
+
+	/**
+	 * Execute the pipeline.
+	 */
+	@Override
+	public boolean execute() {
+		for (AbstractAlgorithm algo : pipeline) {
+			if (algo.execute()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/vne.algorithms/src/algorithms/gips/GipsAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/GipsAlgorithm.java
@@ -1,0 +1,31 @@
+package algorithms.gips;
+
+import java.util.Map;
+
+import org.emoflon.gips.core.milp.SolverOutput;
+
+import algorithms.Algorithm;
+
+/**
+ * This interface defines the additional methods of the GIPS algorithm.
+ * 
+ * @author Janik Stracke {@literal <janik.stracke@stud.tu-darmstadt.de>}
+ */
+public interface GipsAlgorithm extends Algorithm {
+
+	/**
+	 * Returns the solver output of the GIPS algorithm.
+	 * 
+	 * @return The solver output containing the results of the GIPS algorithm.
+	 */
+	public abstract SolverOutput getSolverOutput();
+
+	/**
+	 * Returns the mapping of virtual nodes to substrate nodes.
+	 * 
+	 * @return A map where the keys are the virtual node IDs and the values are the
+	 *         substrate node IDs.
+	 */
+	public abstract Map<String, String> getMatches();
+
+}

--- a/vne.algorithms/src/algorithms/gips/VneGipsAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsAlgorithm.java
@@ -26,19 +26,27 @@ public class VneGipsAlgorithm extends AbstractAlgorithm implements GipsAlgorithm
 	 */
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne";
 
+	/**
+	 * The GIPS MdVNE adapter.
+	 */
 	private final MdvneGipsIflyeAdapter iflyeAdapter;
 
+	/**
+	 * The most recent GIPS MdVNE output.
+	 */
 	private MdvneGipsIflyeAdapter.MdvneIflyeOutput iflyeOutput;
 
 	/**
-	 * Initializes a new abstract algorithm
+	 * Initializes a new GIPS algorithm with the global model facade.
 	 */
 	public VneGipsAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Create a new GIPS algorithm instance with the given model facade.
+	 * 
+	 * @param modelFacade The model facade to use.
 	 */
 	public VneGipsAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/gips/VneGipsAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsAlgorithm.java
@@ -1,9 +1,10 @@
 package algorithms.gips;
 
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.emoflon.gips.core.milp.SolverOutput;
 import org.emoflon.gips.gipsl.examples.mdvne.MdvneGipsIflyeAdapter;
 
 import algorithms.AbstractAlgorithm;
@@ -18,26 +19,38 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VneGipsAlgorithm extends AbstractAlgorithm {
+public class VneGipsAlgorithm extends AbstractAlgorithm implements GipsAlgorithm {
 
 	/**
 	 * Relative base path of the GIPS MdVNE project.
 	 */
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne";
 
-	/**
-	 * Algorithm instance (singleton).
-	 */
-	private static VneGipsAlgorithm instance;
+	private final MdvneGipsIflyeAdapter iflyeAdapter;
+
+	private MdvneGipsIflyeAdapter.MdvneIflyeOutput iflyeOutput;
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initializes a new abstract algorithm
 	 */
-	public VneGipsAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VneGipsAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public VneGipsAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
+
+		iflyeAdapter = new MdvneGipsIflyeAdapter();
+	}
+
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+		VneGipsAlgorithmUtils.checkGivenVnets(getModelFacade(), vNets);
+
+		super.prepare(sNet, vNets);
 	}
 
 	@Override
@@ -49,55 +62,36 @@ public class VneGipsAlgorithm extends AbstractAlgorithm {
 		}
 
 		// TODO: Time measurement
-		final ResourceSet model = ModelFacade.getInstance().getResourceSet();
-		final boolean gipsSuccess = MdvneGipsIflyeAdapter.execute(model,
+		final ResourceSet model = getModelFacade().getResourceSet();
+		this.iflyeOutput = iflyeAdapter.execute(model,
 				GIPS_PROJECT_BASE_PATH + "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/api/gips/gips-model.xmi",
 				GIPS_PROJECT_BASE_PATH + "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/api/ibex-patterns.xmi",
 				GIPS_PROJECT_BASE_PATH + "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/hipe/engine/hipe-network.xmi");
 
+		final boolean gipsSuccess = this.iflyeOutput.solverOutput().solutionCount() > 0;
+
 		// Workaround to fix the residual bandwidth of other paths possibly affected by
 		// virtual link to substrate path embeddings
-		ModelFacade.getInstance().updateAllPathsResidualBandwidth(sNet.getName());
+		getModelFacade().updateAllPathsResidualBandwidth(sNet.getName());
+
 		return gipsSuccess;
 	}
 
-	/**
-	 * Initializes a new instance of the GIPS-based VNE algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
-	 */
-	public static VneGipsAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
+	@Override
+	public SolverOutput getSolverOutput() {
+		return this.iflyeOutput.solverOutput();
+	}
 
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		VneGipsAlgorithmUtils.checkGivenVnets(vNets);
-
-		if (instance == null) {
-			instance = new VneGipsAlgorithm(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		return instance;
+	@Override
+	public Map<String, String> getMatches() {
+		return this.iflyeOutput.matches();
 	}
 
 	/**
 	 * Resets the algorithm instance.
 	 */
 	public void dispose() {
-		MdvneGipsIflyeAdapter.resetInit();
-		if (instance == null) {
-			return;
-		}
-		instance = null;
+		iflyeAdapter.resetInit();
 	}
 
 }

--- a/vne.algorithms/src/algorithms/gips/VneGipsAlgorithmUtils.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsAlgorithmUtils.java
@@ -16,12 +16,12 @@ public class VneGipsAlgorithmUtils {
 	 * 
 	 * @param vNets Set of virtual networks to check for.
 	 */
-	protected static void checkGivenVnets(final Set<VirtualNetwork> vNets) {
+	protected static void checkGivenVnets(final ModelFacade modelFacade, final Set<VirtualNetwork> vNets) {
 		if (vNets == null) {
 			throw new IllegalArgumentException("Virtual network set was null.");
 		}
 
-		final Collection<Network> modelNets = ModelFacade.getInstance().getAllNetworks();
+		final Collection<Network> modelNets = modelFacade.getAllNetworks();
 		final Set<VirtualNetwork> modelVnets = new HashSet<VirtualNetwork>();
 		for (final Network n : modelNets) {
 			if (n instanceof VirtualNetwork vnet) {
@@ -32,8 +32,9 @@ public class VneGipsAlgorithmUtils {
 		}
 
 		if (vNets.size() != modelVnets.size()) {
-			throw new IllegalStateException("Number of given virtual networks does not match the number of "
-					+ "non-embedded virtual networks existing in the model.");
+			throw new IllegalStateException(
+					"Number of given virtual networks (" + vNets.size() + ") does not match the number of "
+							+ "non-embedded virtual networks (" + modelVnets.size() + ") existing in the model.");
 		}
 
 		if (!vNets.containsAll(modelVnets) || !modelVnets.containsAll(vNets)) {

--- a/vne.algorithms/src/algorithms/gips/VneGipsBwIgnoreAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsBwIgnoreAlgorithm.java
@@ -1,9 +1,10 @@
 package algorithms.gips;
 
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.emoflon.gips.core.milp.SolverOutput;
 import org.emoflon.gips.gipsl.examples.mdvne.bwignore.MdvneGipsBwIgnoreIflyeAdapter;
 
 import algorithms.AbstractAlgorithm;
@@ -20,7 +21,7 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VneGipsBwIgnoreAlgorithm extends AbstractAlgorithm {
+public class VneGipsBwIgnoreAlgorithm extends AbstractAlgorithm implements GipsAlgorithm {
 
 	/**
 	 * Relative base path of the GIPS MdVNE project.
@@ -33,13 +34,17 @@ public class VneGipsBwIgnoreAlgorithm extends AbstractAlgorithm {
 	private static VneGipsBwIgnoreAlgorithm instance;
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initializes a new abstract algorithm with a given substrate and given virtual
 	 */
-	public VneGipsBwIgnoreAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VneGipsBwIgnoreAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor that gets the substrate as well as the virtual network.
+	 */
+	public VneGipsBwIgnoreAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	@Override
@@ -56,7 +61,7 @@ public class VneGipsBwIgnoreAlgorithm extends AbstractAlgorithm {
 		}
 
 		// TODO: Time measurement
-		final ResourceSet model = ModelFacade.getInstance().getResourceSet();
+		final ResourceSet model = getModelFacade().getResourceSet();
 		final boolean gipsSuccess = MdvneGipsBwIgnoreIflyeAdapter.execute(model,
 				GIPS_PROJECT_BASE_PATH
 						+ "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/bwignore/api/gips/gips-model.xmi",
@@ -69,8 +74,18 @@ public class VneGipsBwIgnoreAlgorithm extends AbstractAlgorithm {
 		// ignoring needed for this VNE algorithm
 //		// Workaround to fix the residual bandwidth of other paths possibly affected by
 //		// virtual link to substrate path embeddings
-//		ModelFacade.getInstance().updateAllPathsResidualBandwidth(sNet.getName());
+//		getModelFacade().updateAllPathsResidualBandwidth(sNet.getName());
 		return gipsSuccess;
+	}
+
+	@Override
+	public SolverOutput getSolverOutput() {
+		return null;
+	}
+
+	@Override
+	public Map<String, String> getMatches() {
+		return null;
 	}
 
 	/**
@@ -80,25 +95,10 @@ public class VneGipsBwIgnoreAlgorithm extends AbstractAlgorithm {
 	 * @param vNets Set of virtual networks to work with.
 	 * @return Instance of this algorithm implementation.
 	 */
-	public static VneGipsBwIgnoreAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+		VneGipsAlgorithmUtils.checkGivenVnets(getModelFacade(), vNets);
 
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		VneGipsAlgorithmUtils.checkGivenVnets(vNets);
-
-		if (instance == null) {
-			instance = new VneGipsBwIgnoreAlgorithm(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		return instance;
+		super.prepare(sNet, vNets);
 	}
 
 	/**

--- a/vne.algorithms/src/algorithms/gips/VneGipsBwIgnoreAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsBwIgnoreAlgorithm.java
@@ -34,14 +34,16 @@ public class VneGipsBwIgnoreAlgorithm extends AbstractAlgorithm implements GipsA
 	private static VneGipsBwIgnoreAlgorithm instance;
 
 	/**
-	 * Initializes a new abstract algorithm with a given substrate and given virtual
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VneGipsBwIgnoreAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VneGipsBwIgnoreAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/gips/VneGipsHeapAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsHeapAlgorithm.java
@@ -1,6 +1,5 @@
 package algorithms.gips;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -67,7 +66,7 @@ public class VneGipsHeapAlgorithm extends AbstractAlgorithm implements GipsAlgor
 		}
 
 		// TODO: Time measurement
-		final ResourceSet model = ModelFacade.getInstance().getResourceSet();
+		final ResourceSet model = getModelFacade().getResourceSet();
 		this.iflyeOutput = iflyeAdapter.execute(model,
 				GIPS_PROJECT_BASE_PATH + "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/heap/api/gips/gips-model.xmi",
 				GIPS_PROJECT_BASE_PATH + "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/heap/api/ibex-patterns.xmi",
@@ -90,6 +89,7 @@ public class VneGipsHeapAlgorithm extends AbstractAlgorithm implements GipsAlgor
 	 * @param vNets Set of virtual networks to work with.
 	 * @return Instance of this algorithm implementation.
 	 */
+	@Override
 	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		VneGipsAlgorithmUtils.checkGivenVnets(getModelFacade(), vNets);
 
@@ -109,6 +109,7 @@ public class VneGipsHeapAlgorithm extends AbstractAlgorithm implements GipsAlgor
 	/**
 	 * Resets the algorithm instance.
 	 */
+	@Override
 	public void dispose() {
 		iflyeAdapter.resetInit();
 	}

--- a/vne.algorithms/src/algorithms/gips/VneGipsHeapAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsHeapAlgorithm.java
@@ -1,9 +1,12 @@
 package algorithms.gips;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.emoflon.gips.core.milp.SolverOutput;
+import org.emoflon.gips.gipsl.examples.mdvne.MdvneGipsIflyeAdapter;
 import org.emoflon.gips.gipsl.examples.mdvne.heap.MdvneGipsHeapIflyeAdapter;
 
 import algorithms.AbstractAlgorithm;
@@ -20,26 +23,31 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VneGipsHeapAlgorithm extends AbstractAlgorithm {
+public class VneGipsHeapAlgorithm extends AbstractAlgorithm implements GipsAlgorithm {
 
 	/**
 	 * Relative base path of the GIPS MdVNE project.
 	 */
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne.heap";
 
-	/**
-	 * Algorithm instance (singleton).
-	 */
-	private static VneGipsHeapAlgorithm instance;
+	private final MdvneGipsHeapIflyeAdapter iflyeAdapter;
+
+	private MdvneGipsIflyeAdapter.MdvneIflyeOutput iflyeOutput;
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initializes a new abstract algorithm
 	 */
-	public VneGipsHeapAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VneGipsHeapAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public VneGipsHeapAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
+
+		iflyeAdapter = new MdvneGipsHeapIflyeAdapter();
 	}
 
 	@Override
@@ -52,15 +60,18 @@ public class VneGipsHeapAlgorithm extends AbstractAlgorithm {
 
 		// TODO: Time measurement
 		final ResourceSet model = ModelFacade.getInstance().getResourceSet();
-		final boolean gipsSuccess = MdvneGipsHeapIflyeAdapter.execute(model,
+		this.iflyeOutput = iflyeAdapter.execute(model,
 				GIPS_PROJECT_BASE_PATH + "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/heap/api/gips/gips-model.xmi",
 				GIPS_PROJECT_BASE_PATH + "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/heap/api/ibex-patterns.xmi",
 				GIPS_PROJECT_BASE_PATH
 						+ "/src-gen/org/emoflon/gips/gipsl/examples/mdvne/heap/hipe/engine/hipe-network.xmi");
 
+		final boolean gipsSuccess = this.iflyeOutput.solverOutput().solutionCount() > 0;
+
 		// Workaround to fix the residual bandwidth of other paths possibly affected by
 		// virtual link to substrate path embeddings
-		ModelFacade.getInstance().updateAllPathsResidualBandwidth(sNet.getName());
+		getModelFacade().updateAllPathsResidualBandwidth(sNet.getName());
+
 		return gipsSuccess;
 	}
 
@@ -71,36 +82,27 @@ public class VneGipsHeapAlgorithm extends AbstractAlgorithm {
 	 * @param vNets Set of virtual networks to work with.
 	 * @return Instance of this algorithm implementation.
 	 */
-	public static VneGipsHeapAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+		VneGipsAlgorithmUtils.checkGivenVnets(getModelFacade(), vNets);
 
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
+		super.prepare(sNet, vNets);
+	}
 
-		VneGipsAlgorithmUtils.checkGivenVnets(vNets);
+	@Override
+	public SolverOutput getSolverOutput() {
+		return this.iflyeOutput.solverOutput();
+	}
 
-		if (instance == null) {
-			instance = new VneGipsHeapAlgorithm(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		return instance;
+	@Override
+	public Map<String, String> getMatches() {
+		return this.iflyeOutput.matches();
 	}
 
 	/**
 	 * Resets the algorithm instance.
 	 */
 	public void dispose() {
-		MdvneGipsHeapIflyeAdapter.resetInit();
-		if (instance == null) {
-			return;
-		}
-		instance = null;
+		iflyeAdapter.resetInit();
 	}
 
 }

--- a/vne.algorithms/src/algorithms/gips/VneGipsHeapAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsHeapAlgorithm.java
@@ -30,19 +30,27 @@ public class VneGipsHeapAlgorithm extends AbstractAlgorithm implements GipsAlgor
 	 */
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne.heap";
 
+	/**
+	 * The GIPS MdVNE adapter.
+	 */
 	private final MdvneGipsHeapIflyeAdapter iflyeAdapter;
 
+	/**
+	 * The most recent GIPS MdVNE output.
+	 */
 	private MdvneGipsIflyeAdapter.MdvneIflyeOutput iflyeOutput;
 
 	/**
-	 * Initializes a new abstract algorithm
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VneGipsHeapAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VneGipsHeapAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/gips/VneGipsLookaheadAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsLookaheadAlgorithm.java
@@ -1,9 +1,10 @@
 package algorithms.gips;
 
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.emoflon.gips.core.milp.SolverOutput;
 import org.emoflon.gips.gipsl.examples.mdvne.MdvneGipsLookaheadIflyeAdapter;
 
 import algorithms.AbstractAlgorithm;
@@ -18,17 +19,12 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VneGipsLookaheadAlgorithm extends AbstractAlgorithm {
+public class VneGipsLookaheadAlgorithm extends AbstractAlgorithm implements GipsAlgorithm {
 
 	/**
 	 * Relative base path of the GIPS MdVNE project.
 	 */
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne";
-
-	/**
-	 * Algorithm instance (singleton).
-	 */
-	private static VneGipsLookaheadAlgorithm instance;
 
 	/**
 	 * The ID of the virtual network to embed.
@@ -44,10 +40,15 @@ public class VneGipsLookaheadAlgorithm extends AbstractAlgorithm {
 	 * @param vNets  Set of virtual networks to work with.
 	 * @param vNetId ID of the virtual network to embed.
 	 */
-	public VneGipsLookaheadAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets,
-			final String vNetId) {
-		super(sNet, vNets);
-		this.vNetId = vNetId;
+	public VneGipsLookaheadAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public VneGipsLookaheadAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	@Override
@@ -99,8 +100,7 @@ public class VneGipsLookaheadAlgorithm extends AbstractAlgorithm {
 	 * @param vNetId ID of the virtual network to embed.
 	 * @return Instance of this algorithm implementation.
 	 */
-	public static VneGipsLookaheadAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets,
-			final String vNetId) {
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets, final String vNetId) {
 		if (sNet == null || vNets == null) {
 			throw new IllegalArgumentException("One of the provided network objects was null.");
 		}
@@ -109,16 +109,19 @@ public class VneGipsLookaheadAlgorithm extends AbstractAlgorithm {
 			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
 		}
 
-		VneGipsAlgorithmUtils.checkGivenVnets(vNets);
+		VneGipsAlgorithmUtils.checkGivenVnets(getModelFacade(), vNets);
+		super.prepare(sNet, vNets);
+		this.vNetId = vNetId;
+	}
 
-		if (instance == null) {
-			instance = new VneGipsLookaheadAlgorithm(sNet, vNets, vNetId);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
+	@Override
+	public SolverOutput getSolverOutput() {
+		return null;
+	}
 
-		return instance;
+	@Override
+	public Map<String, String> getMatches() {
+		return null;
 	}
 
 	/**
@@ -126,14 +129,11 @@ public class VneGipsLookaheadAlgorithm extends AbstractAlgorithm {
 	 */
 	public void dispose() {
 		MdvneGipsLookaheadIflyeAdapter.resetInit();
-		if (instance == null) {
-			return;
-		}
-		instance = null;
 	}
 
-	public static AbstractAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		return prepare(sNet, vNets, null);
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+		prepare(sNet, vNets, null);
 	}
 
 }

--- a/vne.algorithms/src/algorithms/gips/VneGipsLookaheadAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsLookaheadAlgorithm.java
@@ -32,7 +32,7 @@ public class VneGipsLookaheadAlgorithm extends AbstractAlgorithm implements Gips
 	private String vNetId = null;
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network. GIPS will
+	 * Initialize the algorithm with the global model facade. GIPS will
 	 * calculate a valid embedding for all given virtual networks but only the one
 	 * whose name matches the given network ID will be embedded within the model.
 	 *
@@ -45,7 +45,9 @@ public class VneGipsLookaheadAlgorithm extends AbstractAlgorithm implements Gips
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VneGipsLookaheadAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/gips/VneGipsMigrationAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsMigrationAlgorithm.java
@@ -28,17 +28,16 @@ public class VneGipsMigrationAlgorithm extends AbstractAlgorithm implements Gips
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne.migration";
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VneGipsMigrationAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VneGipsMigrationAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/gips/VneGipsMigrationAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsMigrationAlgorithm.java
@@ -1,9 +1,10 @@
 package algorithms.gips;
 
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.emoflon.gips.core.milp.SolverOutput;
 import org.emoflon.gips.gipsl.examples.mdvne.migration.MdvneMigrationGipsIflyeAdapter;
 
 import algorithms.AbstractAlgorithm;
@@ -19,7 +20,7 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VneGipsMigrationAlgorithm extends AbstractAlgorithm {
+public class VneGipsMigrationAlgorithm extends AbstractAlgorithm implements GipsAlgorithm {
 
 	/**
 	 * Relative base path of the GIPS MdVNE project.
@@ -27,18 +28,20 @@ public class VneGipsMigrationAlgorithm extends AbstractAlgorithm {
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne.migration";
 
 	/**
-	 * Algorithm instance (singleton).
-	 */
-	private static VneGipsMigrationAlgorithm instance;
-
-	/**
 	 * Constructor that gets the substrate as well as the virtual network.
 	 *
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	public VneGipsMigrationAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VneGipsMigrationAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public VneGipsMigrationAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	@Override
@@ -86,7 +89,8 @@ public class VneGipsMigrationAlgorithm extends AbstractAlgorithm {
 	 * @param vNets Set of virtual networks to work with.
 	 * @return Instance of this algorithm implementation.
 	 */
-	public static VneGipsMigrationAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		if (sNet == null || vNets == null) {
 			throw new IllegalArgumentException("One of the provided network objects was null.");
 		}
@@ -95,16 +99,18 @@ public class VneGipsMigrationAlgorithm extends AbstractAlgorithm {
 			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
 		}
 
-		VneGipsAlgorithmUtils.checkGivenVnets(vNets);
+		VneGipsAlgorithmUtils.checkGivenVnets(getModelFacade(), vNets);
+		super.prepare(sNet, vNets);
+	}
 
-		if (instance == null) {
-			instance = new VneGipsMigrationAlgorithm(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
+	@Override
+	public SolverOutput getSolverOutput() {
+		return null;
+	}
 
-		return instance;
+	@Override
+	public Map<String, String> getMatches() {
+		return null;
 	}
 
 	/**
@@ -112,10 +118,6 @@ public class VneGipsMigrationAlgorithm extends AbstractAlgorithm {
 	 */
 	public void dispose() {
 		MdvneMigrationGipsIflyeAdapter.resetInit();
-		if (instance == null) {
-			return;
-		}
-		instance = null;
 	}
 
 }

--- a/vne.algorithms/src/algorithms/gips/VneGipsSeqAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsSeqAlgorithm.java
@@ -27,17 +27,16 @@ public class VneGipsSeqAlgorithm extends AbstractAlgorithm implements GipsAlgori
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne.seq";
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VneGipsSeqAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VneGipsSeqAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/gips/VneGipsSeqAlgorithm.java
+++ b/vne.algorithms/src/algorithms/gips/VneGipsSeqAlgorithm.java
@@ -1,9 +1,10 @@
 package algorithms.gips;
 
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.emoflon.gips.core.milp.SolverOutput;
 import org.emoflon.gips.gipsl.examples.mdvne.seq.MdvneSeqGipsIflyeAdapter;
 
 import algorithms.AbstractAlgorithm;
@@ -18,7 +19,7 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VneGipsSeqAlgorithm extends AbstractAlgorithm {
+public class VneGipsSeqAlgorithm extends AbstractAlgorithm implements GipsAlgorithm {
 
 	/**
 	 * Relative base path of the GIPS MdVNE project.
@@ -26,18 +27,20 @@ public class VneGipsSeqAlgorithm extends AbstractAlgorithm {
 	private final static String GIPS_PROJECT_BASE_PATH = "../../gips-examples/org.emoflon.gips.gipsl.examples.mdvne.seq";
 
 	/**
-	 * Algorithm instance (singleton).
-	 */
-	private static VneGipsSeqAlgorithm instance;
-
-	/**
 	 * Constructor that gets the substrate as well as the virtual network.
 	 *
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	public VneGipsSeqAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VneGipsSeqAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public VneGipsSeqAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	@Override
@@ -69,7 +72,8 @@ public class VneGipsSeqAlgorithm extends AbstractAlgorithm {
 	 * @param vNets Set of virtual networks to work with.
 	 * @return Instance of this algorithm implementation.
 	 */
-	public static VneGipsSeqAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		if (sNet == null || vNets == null) {
 			throw new IllegalArgumentException("One of the provided network objects was null.");
 		}
@@ -78,16 +82,18 @@ public class VneGipsSeqAlgorithm extends AbstractAlgorithm {
 			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
 		}
 
-		VneGipsAlgorithmUtils.checkGivenVnets(vNets);
+		VneGipsAlgorithmUtils.checkGivenVnets(getModelFacade(), vNets);
+		super.prepare(sNet, vNets);
+	}
 
-		if (instance == null) {
-			instance = new VneGipsSeqAlgorithm(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
+	@Override
+	public SolverOutput getSolverOutput() {
+		return null;
+	}
 
-		return instance;
+	@Override
+	public Map<String, String> getMatches() {
+		return null;
 	}
 
 	/**
@@ -95,10 +101,6 @@ public class VneGipsSeqAlgorithm extends AbstractAlgorithm {
 	 */
 	public void dispose() {
 		MdvneSeqGipsIflyeAdapter.resetInit();
-		if (instance == null) {
-			return;
-		}
-		instance = null;
 	}
 
 }

--- a/vne.algorithms/src/algorithms/heuristics/TafAlgorithm.java
+++ b/vne.algorithms/src/algorithms/heuristics/TafAlgorithm.java
@@ -181,17 +181,16 @@ public class TafAlgorithm extends AbstractAlgorithm {
 	}
 
 	/**
-	 * Public constructor that initializes the instance of this algorithm.
-	 *
-	 * @param sNet  Substrate network to embed virtual network in.
-	 * @param vNets Virtual network to generate embedding for.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public TafAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public TafAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/heuristics/TafAlgorithm.java
+++ b/vne.algorithms/src/algorithms/heuristics/TafAlgorithm.java
@@ -202,6 +202,8 @@ public class TafAlgorithm extends AbstractAlgorithm {
 			throw new IllegalArgumentException("The TAF algorithm is only suited for one virtual network at a time.");
 		}
 
+		super.prepare(sNet, vNets);
+
 		virtualLinks.clear();
 		// Add virtual links from model
 		final List<Link> vLinks = modelFacade.getAllLinksOfNetwork(getFirstVnet().getName());

--- a/vne.algorithms/src/algorithms/ilp/VneFakeIlpAlgorithm.java
+++ b/vne.algorithms/src/algorithms/ilp/VneFakeIlpAlgorithm.java
@@ -303,17 +303,16 @@ public class VneFakeIlpAlgorithm extends AbstractAlgorithm {
 	protected final Set<VirtualNetwork> ignoredVnets = new HashSet<>();
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VneFakeIlpAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VneFakeIlpAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/ilp/VneFakeIlpBatchAlgorithm.java
+++ b/vne.algorithms/src/algorithms/ilp/VneFakeIlpBatchAlgorithm.java
@@ -1,8 +1,8 @@
 package algorithms.ilp;
 
-import java.util.HashSet;
 import java.util.Set;
 
+import facade.ModelFacade;
 import gt.PatternMatchingDelta;
 import metrics.manager.GlobalMetricsManager;
 import model.SubstrateNetwork;
@@ -29,8 +29,15 @@ public class VneFakeIlpBatchAlgorithm extends VneFakeIlpAlgorithm {
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VneFakeIlpBatchAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VneFakeIlpBatchAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public VneFakeIlpBatchAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	/**
@@ -40,7 +47,8 @@ public class VneFakeIlpBatchAlgorithm extends VneFakeIlpAlgorithm {
 	 * @param vNets Set of virtual networks to work with.
 	 * @return Instance of this algorithm implementation.
 	 */
-	public static VneFakeIlpAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		if (sNet == null || vNets == null) {
 			throw new IllegalArgumentException("One of the provided network objects was null.");
 		}
@@ -49,16 +57,13 @@ public class VneFakeIlpBatchAlgorithm extends VneFakeIlpAlgorithm {
 			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
 		}
 
-		if (instance == null) {
-			instance = new VneFakeIlpBatchAlgorithm(sNet, vNets);
-		}
-		setSnet(sNet);
-		final Set<VirtualNetwork> vNetsInt = new HashSet<>();
-		vNetsInt.addAll(vNets);
-		setVnets(vNetsInt);
+//		setSnet(sNet);
+//		final Set<VirtualNetwork> vNetsInt = new HashSet<>();
+//		vNetsInt.addAll(vNets);
+//		setVnets(vNetsInt);
+		super.prepare(sNet, vNets);
 
-		instance.checkPreConditions();
-		return instance;
+		checkPreConditions();
 	}
 
 	protected void preHook() {
@@ -71,7 +76,7 @@ public class VneFakeIlpBatchAlgorithm extends VneFakeIlpAlgorithm {
 		vNets.forEach(vn -> {
 			if (vn.getHost() != null) {
 				System.out.println("=> Un-embed virtual network " + vn.getName());
-				facade.removeNetworkEmbedding(vn.getName());
+				modelFacade.removeNetworkEmbedding(vn.getName());
 			}
 		});
 	}

--- a/vne.algorithms/src/algorithms/ilp/VneFakeIlpBatchAlgorithm.java
+++ b/vne.algorithms/src/algorithms/ilp/VneFakeIlpBatchAlgorithm.java
@@ -24,17 +24,16 @@ import model.VirtualNetwork;
 public class VneFakeIlpBatchAlgorithm extends VneFakeIlpAlgorithm {
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VneFakeIlpBatchAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VneFakeIlpBatchAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithm.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithm.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import algorithms.AbstractAlgorithm;
 import algorithms.AlgorithmConfig;
+import facade.ModelFacade;
 import facade.config.ModelFacadeConfig;
 import gt.IncrementalPatternMatcher;
 import gt.PatternMatchingDelta;
@@ -117,7 +118,7 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 		 */
 		public void addLinkServerMatch(final Match match) {
 			final String varName = match.getVirtual().getName() + "_" + match.getSubstrate().getName();
-			final VirtualLink vLink = (VirtualLink) facade.getLinkById(match.getVirtual().getName());
+			final VirtualLink vLink = (VirtualLink) modelFacade.getLinkById(match.getVirtual().getName());
 
 			// If the source node (target node) of the virtual link may not be embedded to
 			// the substrate
@@ -151,8 +152,8 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 		 * @param match Match to get information from.
 		 */
 		public void addLinkPathMatch(final Match match) {
-			final VirtualLink vLink = (VirtualLink) facade.getLinkById(match.getVirtual().getName());
-			final SubstratePath sPath = facade.getPathById(match.getSubstrate().getName());
+			final VirtualLink vLink = (VirtualLink) modelFacade.getLinkById(match.getVirtual().getName());
+			final SubstratePath sPath = modelFacade.getPathById(match.getSubstrate().getName());
 
 			// If the source node (target node) of the virtual link may not be embedded to
 			// the substrate
@@ -193,7 +194,7 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 		 * @param match Match to get information from.
 		 */
 		public void addServerMatch(final Match match) {
-			final VirtualServer vServer = (VirtualServer) facade.getServerById(match.getVirtual().getName());
+			final VirtualServer vServer = (VirtualServer) modelFacade.getServerById(match.getVirtual().getName());
 			final String varName = match.getVirtual().getName() + "_" + match.getSubstrate().getName();
 			delta.addVariable(varName, getCost(vServer, (SubstrateServer) match.getSubstrate()));
 			delta.setVariableWeightForConstraint("vs" + match.getVirtual().getName(), 1, varName);
@@ -289,11 +290,6 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	}
 
 	/**
-	 * Algorithm instance (singleton).
-	 */
-	protected static VnePmMdvneAlgorithm instance;
-
-	/**
 	 * Incremental pattern matcher to use.
 	 */
 	protected IncrementalPatternMatcher patternMatcher;
@@ -321,8 +317,15 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VnePmMdvneAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public VnePmMdvneAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	/**
@@ -332,7 +335,8 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	 * @param vNets Set of virtual networks to work with.
 	 * @return Instance of this algorithm implementation.
 	 */
-	public static VnePmMdvneAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		if (sNet == null || vNets == null) {
 			throw new IllegalArgumentException("One of the provided network objects was null.");
 		}
@@ -341,31 +345,21 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
 		}
 
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithm(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
+		super.prepare(sNet, vNets);
 
-		instance.checkPreConditions();
-		return instance;
+		checkPreConditions();
 	}
 
 	/**
 	 * Resets the ILP solver and the pattern matcher.
 	 */
 	public void dispose() {
-		if (instance == null) {
-			return;
-		}
 		if (this.ilpSolver != null) {
 			this.ilpSolver.dispose();
 		}
 		if (this.patternMatcher != null) {
 			this.patternMatcher.dispose();
 		}
-		instance = null;
 	}
 
 	@Override
@@ -518,10 +512,10 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	protected void repairSubstrateNetwork() {
 		// Find all networks that were removed in the meantime
 		final Set<VirtualNetwork> removedGuests = sNet.getGuests().stream()
-				.filter(g -> !facade.networkExists(g.getName())).collect(Collectors.toSet());
+				.filter(g -> !modelFacade.networkExists(g.getName())).collect(Collectors.toSet());
 
 		// Remove embedding of all elements of the virtual network
-		removedGuests.forEach(g -> facade.unembedVirtualNetwork(g));
+		removedGuests.forEach(g -> modelFacade.unembedVirtualNetwork(g));
 	}
 
 	/**
@@ -536,12 +530,12 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	 */
 	protected Set<VirtualNetwork> repairVirtualNetworks() {
 		// Find all virtual networks that are floating
-		final Set<VirtualNetwork> floatingGuests = sNet.getGuests().stream().filter(g -> facade.checkIfFloating(g))
+		final Set<VirtualNetwork> floatingGuests = sNet.getGuests().stream().filter(g -> modelFacade.checkIfFloating(g))
 				.collect(Collectors.toSet());
 
 		// Remove embedding of all elements of the virtual network so they can be
 		// embedded again
-		floatingGuests.forEach(g -> facade.unembedVirtualNetwork(g));
+		floatingGuests.forEach(g -> modelFacade.unembedVirtualNetwork(g));
 		return floatingGuests;
 	}
 
@@ -570,7 +564,7 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	protected void embedNetworks(final Set<VirtualNetwork> rejectedNetworks) {
 		for (final VirtualNetwork vNet : vNets) {
 			if (!rejectedNetworks.contains(vNet)) {
-				facade.embedNetworkToNetwork(sNet.getName(), vNet.getName());
+				modelFacade.embedNetworkToNetwork(sNet.getName(), vNet.getName());
 			}
 		}
 	}
@@ -665,14 +659,14 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 				final VirtualElement ve = (VirtualElement) m.getVirtual();
 				final SubstrateElement se = (SubstrateElement) m.getSubstrate();
 				if (ve instanceof VirtualServer) {
-					facade.embedServerToServer(se.getName(), ve.getName());
+					modelFacade.embedServerToServer(se.getName(), ve.getName());
 				} else if (ve instanceof VirtualSwitch) {
-					facade.embedSwitchToNode(se.getName(), ve.getName());
+					modelFacade.embedSwitchToNode(se.getName(), ve.getName());
 				} else if (ve instanceof VirtualLink) {
 					if (se instanceof SubstrateServer) {
-						facade.embedLinkToServer(se.getName(), ve.getName());
+						modelFacade.embedLinkToServer(se.getName(), ve.getName());
 					} else if (se instanceof SubstratePath) {
-						facade.embedLinkToPath(se.getName(), ve.getName());
+						modelFacade.embedLinkToPath(se.getName(), ve.getName());
 					}
 				}
 				break;
@@ -681,7 +675,7 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 
 		// Workaround to fix the residual bandwidth of other paths possibly affected by
 		// virtual link to substrate path embeddings
-		facade.updateAllPathsResidualBandwidth(sNet.getName());
+		modelFacade.updateAllPathsResidualBandwidth(sNet.getName());
 
 		return rejectedNetworks;
 	}
@@ -709,8 +703,8 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	 *
 	 * @param sNet Substrate network to set.
 	 */
-	protected static void setSnet(final SubstrateNetwork sNet) {
-		instance.sNet = sNet;
+	protected void setSnet(final SubstrateNetwork sNet) {
+		this.sNet = sNet;
 	}
 
 	/**
@@ -719,8 +713,8 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	 *
 	 * @param vNets Virtual networks to set.
 	 */
-	protected static void setVnets(final Set<VirtualNetwork> vNets) {
-		instance.vNets = vNets;
+	protected void setVnets(final Set<VirtualNetwork> vNets) {
+		this.vNets = vNets;
 	}
 
 	/*

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithm.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithm.java
@@ -312,17 +312,16 @@ public class VnePmMdvneAlgorithm extends AbstractAlgorithm {
 	protected final Set<VirtualNetwork> ignoredVnets = new HashSet<>();
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmMigration.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmMigration.java
@@ -43,17 +43,16 @@ public class VnePmMdvneAlgorithmMigration extends VnePmMdvneAlgorithm {
 	final PatternMatchingDelta globalDelta = new PatternMatchingDelta();
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmMigration() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmMigration(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmMigration.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmMigration.java
@@ -9,7 +9,6 @@ import gt.PatternMatchingDelta;
 import gt.emoflon.EmoflonGtFactory;
 import metrics.manager.GlobalMetricsManager;
 import model.Node;
-import model.SubstrateNetwork;
 import model.VirtualNetwork;
 import model.VirtualServer;
 
@@ -49,37 +48,15 @@ public class VnePmMdvneAlgorithmMigration extends VnePmMdvneAlgorithm {
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	private VnePmMdvneAlgorithmMigration(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithmMigration() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Initializes a new instance of the VNE pattern matching algorithm with
-	 * migration functionality.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
+	 * Constructor.
 	 */
-	public static VnePmMdvneAlgorithm prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
-
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithmMigration(sNet, vNets);
-		}
-		setSnet(sNet);
-		final Set<VirtualNetwork> vNetsInt = new HashSet<>();
-		vNetsInt.addAll(vNets);
-		setVnets(vNetsInt);
-
-		instance.checkPreConditions();
-		return instance;
+	public VnePmMdvneAlgorithmMigration(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	@Override

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineThreeStagesA.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineThreeStagesA.java
@@ -16,14 +16,16 @@ import facade.ModelFacade;
 public class VnePmMdvneAlgorithmPipelineThreeStagesA extends VnePmMdvnePipelineAlgorithm {
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmPipelineThreeStagesA() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmPipelineThreeStagesA(final ModelFacade modelFacade) {
 		super(modelFacade, List.of(new VnePmMdvneAlgorithmPipelineStageVnet(modelFacade),

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineThreeStagesA.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineThreeStagesA.java
@@ -1,14 +1,9 @@
 package algorithms.pm;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import algorithms.AbstractAlgorithm;
+import java.util.List;
 import algorithms.pm.stages.VnePmMdvneAlgorithmPipelineStageRackA;
 import algorithms.pm.stages.VnePmMdvneAlgorithmPipelineStageVnet;
-import metrics.manager.GlobalMetricsManager;
-import model.SubstrateNetwork;
-import model.VirtualNetwork;
+import facade.ModelFacade;
 
 /**
  * Implementation of the model-driven virtual network algorithm that uses
@@ -18,121 +13,21 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineThreeStagesA extends VnePmMdvneAlgorithm {
-
-	/**
-	 * Algorithm instance (singleton).
-	 */
-	protected static VnePmMdvneAlgorithmPipelineThreeStagesA instance;
+public class VnePmMdvneAlgorithmPipelineThreeStagesA extends VnePmMdvnePipelineAlgorithm {
 
 	/**
 	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VnePmMdvneAlgorithmPipelineThreeStagesA(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithmPipelineThreeStagesA() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Initializes a new instance of the VNE pattern matching algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
+	 * Constructor.
 	 */
-	public static VnePmMdvneAlgorithmPipelineThreeStagesA prepare(final SubstrateNetwork sNet,
-			final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
-
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithmPipelineThreeStagesA(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		instance.checkPreConditions();
-		return instance;
-	}
-
-	/**
-	 * Resets the ILP solver and the pattern matcher.
-	 */
-	@Override
-	public void dispose() {
-		if (instance == null) {
-			return;
-		}
-		super.dispose();
-		instance = null;
-
-		// Dispose also the first two stages
-		VnePmMdvneAlgorithmPipelineStageVnet.prepare(sNet, vNets).dispose();
-		VnePmMdvneAlgorithmPipelineStageRackA.prepare(sNet, vNets).dispose();
-	}
-
-	@Override
-	public boolean execute() {
-		GlobalMetricsManager.measureMemory();
-		init();
-
-		// Check overall embedding possibility
-		checkOverallResources();
-
-		// Repair model consistency: Substrate network
-		repairSubstrateNetwork();
-
-		// Repair model consistency: Virtual network(s)
-		final Set<VirtualNetwork> repairedVnets = repairVirtualNetworks();
-		// if (!repairedVnets.isEmpty()) {
-		// this.patternMatcher = new EmoflonGtFactory().create();
-		// this.patternMatcherVnet = new EmoflonGtVnetFactory().create();
-		// }
-		vNets.addAll(repairedVnets);
-
-		//
-		// Stage 1: Virtual network -> Substrate server
-		//
-
-		System.out.println("=> Starting pipeline stage #1");
-		AbstractAlgorithm algo = VnePmMdvneAlgorithmPipelineStageVnet.prepare(sNet, vNets);
-		if (algo.execute()) {
-			return true;
-		}
-
-		//
-		// Stage 2: Virtual network -> Substrate Rack
-		//
-
-		// Remove embedding of all already embedded networks
-		PmAlgorithmUtils.unembedAll(sNet, vNets);
-
-		System.out.println("=> Starting pipeline stage #2");
-		dispose();
-		algo = VnePmMdvneAlgorithmPipelineStageRackA.prepare(sNet, vNets);
-		if (algo.execute()) {
-			return true;
-		}
-
-		//
-		// Stage 3: Normal PM-based embedding
-		//
-
-		// Remove embedding of all already embedded networks
-		PmAlgorithmUtils.unembedAll(sNet, vNets);
-
-		System.out.println("=> Starting pipeline stage #3");
-		dispose();
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
-		return algo.execute();
+	public VnePmMdvneAlgorithmPipelineThreeStagesA(final ModelFacade modelFacade) {
+		super(modelFacade, List.of(new VnePmMdvneAlgorithmPipelineStageVnet(modelFacade),
+				new VnePmMdvneAlgorithmPipelineStageRackA(modelFacade), new VnePmMdvneAlgorithm(modelFacade)));
 	}
 
 }

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineThreeStagesB.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineThreeStagesB.java
@@ -16,14 +16,16 @@ import facade.ModelFacade;
 public class VnePmMdvneAlgorithmPipelineThreeStagesB extends VnePmMdvnePipelineAlgorithm {
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmPipelineThreeStagesB() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmPipelineThreeStagesB(final ModelFacade modelFacade) {
 		super(modelFacade, List.of(new VnePmMdvneAlgorithmPipelineStageVnet(modelFacade),

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineThreeStagesB.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineThreeStagesB.java
@@ -1,14 +1,9 @@
 package algorithms.pm;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import algorithms.AbstractAlgorithm;
+import java.util.List;
 import algorithms.pm.stages.VnePmMdvneAlgorithmPipelineStageRackB;
 import algorithms.pm.stages.VnePmMdvneAlgorithmPipelineStageVnet;
-import metrics.manager.GlobalMetricsManager;
-import model.SubstrateNetwork;
-import model.VirtualNetwork;
+import facade.ModelFacade;
 
 /**
  * Implementation of the model-driven virtual network algorithm that uses
@@ -18,121 +13,21 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineThreeStagesB extends VnePmMdvneAlgorithm {
-
-	/**
-	 * Algorithm instance (singleton).
-	 */
-	protected static VnePmMdvneAlgorithmPipelineThreeStagesB instance;
+public class VnePmMdvneAlgorithmPipelineThreeStagesB extends VnePmMdvnePipelineAlgorithm {
 
 	/**
 	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VnePmMdvneAlgorithmPipelineThreeStagesB(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithmPipelineThreeStagesB() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Initializes a new instance of the VNE pattern matching algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
+	 * Constructor.
 	 */
-	public static VnePmMdvneAlgorithmPipelineThreeStagesB prepare(final SubstrateNetwork sNet,
-			final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
-
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithmPipelineThreeStagesB(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		instance.checkPreConditions();
-		return instance;
-	}
-
-	/**
-	 * Resets the ILP solver and the pattern matcher.
-	 */
-	@Override
-	public void dispose() {
-		if (instance == null) {
-			return;
-		}
-		super.dispose();
-		instance = null;
-
-		// Dispose also the first two stages
-		VnePmMdvneAlgorithmPipelineStageVnet.prepare(sNet, vNets).dispose();
-		VnePmMdvneAlgorithmPipelineStageRackB.prepare(sNet, vNets).dispose();
-	}
-
-	@Override
-	public boolean execute() {
-		GlobalMetricsManager.measureMemory();
-		init();
-
-		// Check overall embedding possibility
-		checkOverallResources();
-
-		// Repair model consistency: Substrate network
-		repairSubstrateNetwork();
-
-		// Repair model consistency: Virtual network(s)
-		final Set<VirtualNetwork> repairedVnets = repairVirtualNetworks();
-		// if (!repairedVnets.isEmpty()) {
-		// this.patternMatcher = new EmoflonGtFactory().create();
-		// this.patternMatcherVnet = new EmoflonGtVnetFactory().create();
-		// }
-		vNets.addAll(repairedVnets);
-
-		//
-		// Stage 1: Virtual network -> Substrate server
-		//
-
-		System.out.println("=> Starting pipeline stage #1");
-		AbstractAlgorithm algo = VnePmMdvneAlgorithmPipelineStageVnet.prepare(sNet, vNets);
-		if (algo.execute()) {
-			return true;
-		}
-
-		//
-		// Stage 2: Virtual network -> Substrate Rack
-		//
-
-		// Remove embedding of all already embedded networks
-		PmAlgorithmUtils.unembedAll(sNet, vNets);
-
-		System.out.println("=> Starting pipeline stage #2");
-		dispose();
-		algo = VnePmMdvneAlgorithmPipelineStageRackB.prepare(sNet, vNets);
-		if (algo.execute()) {
-			return true;
-		}
-
-		//
-		// Stage 3: Normal PM-based embedding
-		//
-
-		// Remove embedding of all already embedded networks
-		PmAlgorithmUtils.unembedAll(sNet, vNets);
-
-		System.out.println("=> Starting pipeline stage #3");
-		dispose();
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
-		return algo.execute();
+	public VnePmMdvneAlgorithmPipelineThreeStagesB(final ModelFacade modelFacade) {
+		super(modelFacade, List.of(new VnePmMdvneAlgorithmPipelineStageVnet(modelFacade),
+				new VnePmMdvneAlgorithmPipelineStageRackB(modelFacade), new VnePmMdvneAlgorithm(modelFacade)));
 	}
 
 }

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesRackA.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesRackA.java
@@ -15,17 +15,16 @@ import facade.ModelFacade;
 public class VnePmMdvneAlgorithmPipelineTwoStagesRackA extends VnePmMdvnePipelineAlgorithm {
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmPipelineTwoStagesRackA() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmPipelineTwoStagesRackA(final ModelFacade modelFacade) {
 		super(modelFacade,

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesRackA.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesRackA.java
@@ -1,13 +1,8 @@
 package algorithms.pm;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import algorithms.AbstractAlgorithm;
+import java.util.List;
 import algorithms.pm.stages.VnePmMdvneAlgorithmPipelineStageRackA;
-import metrics.manager.GlobalMetricsManager;
-import model.SubstrateNetwork;
-import model.VirtualNetwork;
+import facade.ModelFacade;
 
 /**
  * Implementation of the model-driven virtual network algorithm that uses
@@ -17,12 +12,7 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineTwoStagesRackA extends VnePmMdvneAlgorithm {
-
-	/**
-	 * Algorithm instance (singleton).
-	 */
-	protected static VnePmMdvneAlgorithmPipelineTwoStagesRackA instance;
+public class VnePmMdvneAlgorithmPipelineTwoStagesRackA extends VnePmMdvnePipelineAlgorithm {
 
 	/**
 	 * Constructor that gets the substrate as well as the virtual network.
@@ -30,93 +20,16 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackA extends VnePmMdvneAlgorit
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VnePmMdvneAlgorithmPipelineTwoStagesRackA(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithmPipelineTwoStagesRackA() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Initializes a new instance of the VNE pattern matching algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
+	 * Constructor.
 	 */
-	public static VnePmMdvneAlgorithmPipelineTwoStagesRackA prepare(final SubstrateNetwork sNet,
-			final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
-
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithmPipelineTwoStagesRackA(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		instance.checkPreConditions();
-		return instance;
-	}
-
-	/**
-	 * Resets the ILP solver and the pattern matcher.
-	 */
-	@Override
-	public void dispose() {
-		if (instance == null) {
-			return;
-		}
-		super.dispose();
-		instance = null;
-
-		// Dispose also the first stage only
-		VnePmMdvneAlgorithmPipelineStageRackA.prepare(sNet, vNets).dispose();
-	}
-
-	@Override
-	public boolean execute() {
-		GlobalMetricsManager.measureMemory();
-		init();
-
-		// Check overall embedding possibility
-		checkOverallResources();
-
-		// Repair model consistency: Substrate network
-		repairSubstrateNetwork();
-
-		// Repair model consistency: Virtual network(s)
-		final Set<VirtualNetwork> repairedVnets = repairVirtualNetworks();
-		// if (!repairedVnets.isEmpty()) {
-		// this.patternMatcher = new EmoflonGtFactory().create();
-		// this.patternMatcherVnet = new EmoflonGtVnetFactory().create();
-		// }
-		vNets.addAll(repairedVnets);
-
-		//
-		// Stage 1: Virtual network -> Rack
-		//
-
-		System.out.println("=> Starting pipeline stage #1");
-		AbstractAlgorithm algo = VnePmMdvneAlgorithmPipelineStageRackA.prepare(sNet, vNets);
-		if (algo.execute()) {
-			return true;
-		}
-
-		//
-		// Stage 2: Normal PM-based embedding
-		//
-
-		// Remove embedding of all already embedded networks
-		PmAlgorithmUtils.unembedAll(sNet, vNets);
-
-		System.out.println("=> Starting pipeline stage #2");
-		dispose();
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
-		return algo.execute();
+	public VnePmMdvneAlgorithmPipelineTwoStagesRackA(final ModelFacade modelFacade) {
+		super(modelFacade,
+				List.of(new VnePmMdvneAlgorithmPipelineStageRackA(modelFacade), new VnePmMdvneAlgorithm(modelFacade)));
 	}
 
 }

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesRackB.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesRackB.java
@@ -1,13 +1,8 @@
 package algorithms.pm;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import algorithms.AbstractAlgorithm;
+import java.util.List;
 import algorithms.pm.stages.VnePmMdvneAlgorithmPipelineStageRackB;
-import metrics.manager.GlobalMetricsManager;
-import model.SubstrateNetwork;
-import model.VirtualNetwork;
+import facade.ModelFacade;
 
 /**
  * Implementation of the model-driven virtual network algorithm that uses
@@ -17,12 +12,7 @@ import model.VirtualNetwork;
  *
  * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
  */
-public class VnePmMdvneAlgorithmPipelineTwoStagesRackB extends VnePmMdvneAlgorithm {
-
-	/**
-	 * Algorithm instance (singleton).
-	 */
-	protected static VnePmMdvneAlgorithmPipelineTwoStagesRackB instance;
+public class VnePmMdvneAlgorithmPipelineTwoStagesRackB extends VnePmMdvnePipelineAlgorithm {
 
 	/**
 	 * Constructor that gets the substrate as well as the virtual network.
@@ -30,93 +20,16 @@ public class VnePmMdvneAlgorithmPipelineTwoStagesRackB extends VnePmMdvneAlgorit
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VnePmMdvneAlgorithmPipelineTwoStagesRackB(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithmPipelineTwoStagesRackB() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Initializes a new instance of the VNE pattern matching algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
+	 * Constructor.
 	 */
-	public static VnePmMdvneAlgorithmPipelineTwoStagesRackB prepare(final SubstrateNetwork sNet,
-			final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
-
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithmPipelineTwoStagesRackB(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		instance.checkPreConditions();
-		return instance;
-	}
-
-	/**
-	 * Resets the ILP solver and the pattern matcher.
-	 */
-	@Override
-	public void dispose() {
-		if (instance == null) {
-			return;
-		}
-		super.dispose();
-		instance = null;
-
-		// Dispose also the first stage only
-		VnePmMdvneAlgorithmPipelineStageRackB.prepare(sNet, vNets).dispose();
-	}
-
-	@Override
-	public boolean execute() {
-		GlobalMetricsManager.measureMemory();
-		init();
-
-		// Check overall embedding possibility
-		checkOverallResources();
-
-		// Repair model consistency: Substrate network
-		repairSubstrateNetwork();
-
-		// Repair model consistency: Virtual network(s)
-		final Set<VirtualNetwork> repairedVnets = repairVirtualNetworks();
-		// if (!repairedVnets.isEmpty()) {
-		// this.patternMatcher = new EmoflonGtFactory().create();
-		// this.patternMatcherVnet = new EmoflonGtVnetFactory().create();
-		// }
-		vNets.addAll(repairedVnets);
-
-		//
-		// Stage 1: Virtual network -> Rack
-		//
-
-		System.out.println("=> Starting pipeline stage #1");
-		AbstractAlgorithm algo = VnePmMdvneAlgorithmPipelineStageRackB.prepare(sNet, vNets);
-		if (algo.execute()) {
-			return true;
-		}
-
-		//
-		// Stage 2: Normal PM-based embedding
-		//
-
-		// Remove embedding of all already embedded networks
-		PmAlgorithmUtils.unembedAll(sNet, vNets);
-
-		System.out.println("=> Starting pipeline stage #2");
-		dispose();
-		algo = VnePmMdvneAlgorithm.prepare(sNet, vNets);
-		return algo.execute();
+	public VnePmMdvneAlgorithmPipelineTwoStagesRackB(final ModelFacade modelFacade) {
+		super(modelFacade,
+				List.of(new VnePmMdvneAlgorithmPipelineStageRackB(modelFacade), new VnePmMdvneAlgorithm(modelFacade)));
 	}
 
 }

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesRackB.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesRackB.java
@@ -15,17 +15,16 @@ import facade.ModelFacade;
 public class VnePmMdvneAlgorithmPipelineTwoStagesRackB extends VnePmMdvnePipelineAlgorithm {
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmPipelineTwoStagesRackB() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmPipelineTwoStagesRackB(final ModelFacade modelFacade) {
 		super(modelFacade,

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesVnet.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvneAlgorithmPipelineTwoStagesVnet.java
@@ -15,17 +15,16 @@ import facade.ModelFacade;
 public class VnePmMdvneAlgorithmPipelineTwoStagesVnet extends VnePmMdvnePipelineAlgorithm {
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmPipelineTwoStagesVnet() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmPipelineTwoStagesVnet(final ModelFacade modelFacade) {
 		super(modelFacade,

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvnePipelineAlgorithm.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvnePipelineAlgorithm.java
@@ -1,0 +1,273 @@
+package algorithms.pm;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import algorithms.AbstractAlgorithm;
+import algorithms.AlgorithmPipeline;
+import facade.ModelFacade;
+import facade.config.ModelFacadeConfig;
+import gt.IncrementalPatternMatcher;
+import gt.PatternMatchingDelta.Match;
+import gt.emoflon.EmoflonGtFactory;
+import ilp.wrapper.IncrementalIlpSolver;
+import ilp.wrapper.config.IlpSolverConfig;
+import metrics.manager.GlobalMetricsManager;
+import model.Node;
+import model.SubstrateNetwork;
+import model.SubstrateServer;
+import model.VirtualNetwork;
+import model.VirtualServer;
+
+/**
+ * Implementation of the model-driven virtual network algorithm that uses
+ * pattern matching as a way to reduce the search space of the ILP solver.
+ *
+ * Parts of this implementation are heavily inspired, taken or adapted from the
+ * idyve project [1].
+ *
+ * [1] Tomaszek, S., Modellbasierte Einbettung von virtuellen Netzwerken in
+ * Rechenzentren, http://dx.doi.org/10.12921/TUPRINTS-00017362. – DOI
+ * 10.12921/TUPRINTS– 00017362, 2020.
+ *
+ * @author Stefan Tomaszek (ES TU Darmstadt) [idyve project]
+ * @author Maximilian Kratz {@literal <maximilian.kratz@es.tu-darmstadt.de>}
+ */
+public abstract class VnePmMdvnePipelineAlgorithm extends AlgorithmPipeline {
+
+	/**
+	 * Incremental pattern matcher to use.
+	 */
+	protected IncrementalPatternMatcher patternMatcher;
+
+	/**
+	 * Incremental ILP solver to use.
+	 */
+	protected IncrementalIlpSolver ilpSolver;
+
+	/**
+	 * Mapping of string (name) to matches.
+	 */
+	protected final Map<String, Match> variablesToMatch = new HashMap<>();
+
+	/**
+	 * Set of ignored virtual networks. Ignored virtual networks are requests, that
+	 * can not fit on the substrate network at all and are therefore ignored (as
+	 * they are not given to the ILP solver).
+	 */
+	protected final Set<VirtualNetwork> ignoredVnets = new HashSet<>();
+
+	/**
+	 * Constructor that gets the substrate as well as the virtual network.
+	 *
+	 * @param sNet  Substrate network to work with.
+	 * @param vNets Set of virtual networks to work with.
+	 */
+	public VnePmMdvnePipelineAlgorithm() {
+		this(ModelFacade.getInstance());
+	}
+
+	public VnePmMdvnePipelineAlgorithm(final Collection<AbstractAlgorithm> pipeline) {
+		this(ModelFacade.getInstance(), pipeline);
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public VnePmMdvnePipelineAlgorithm(final ModelFacade modelFacade) {
+		this(modelFacade, List.of());
+	}
+
+	public VnePmMdvnePipelineAlgorithm(final ModelFacade modelFacade, final Collection<AbstractAlgorithm> pipeline) {
+		super(modelFacade, pipeline);
+	}
+
+	/**
+	 * Initializes a new instance of the VNE pattern matching algorithm.
+	 *
+	 * @param sNet  Substrate network to work with.
+	 * @param vNets Set of virtual networks to work with.
+	 * @return Instance of this algorithm implementation.
+	 */
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+		if (sNet == null || vNets == null) {
+			throw new IllegalArgumentException("One of the provided network objects was null.");
+		}
+
+		if (vNets.size() == 0) {
+			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
+		}
+
+		super.prepare(sNet, vNets);
+
+		checkPreConditions();
+	}
+
+	/**
+	 * Resets the ILP solver and the pattern matcher.
+	 */
+	public void dispose() {
+		if (this.ilpSolver != null) {
+			this.ilpSolver.dispose();
+		}
+		if (this.patternMatcher != null) {
+			this.patternMatcher.dispose();
+		}
+
+		super.dispose();
+	}
+
+	@Override
+	public boolean execute() {
+		GlobalMetricsManager.measureMemory();
+		init();
+
+		// Check overall embedding possibility
+		checkOverallResources();
+
+		// Repair model consistency: Substrate network
+		repairSubstrateNetwork();
+
+		// Repair model consistency: Virtual network(s)
+		final Set<VirtualNetwork> repairedVnets = repairVirtualNetworks();
+		if (!repairedVnets.isEmpty()) {
+			this.patternMatcher = new EmoflonGtFactory().create();
+		}
+		vNets.addAll(repairedVnets);
+
+		int stage = 0;
+		for (AbstractAlgorithm algo : pipeline) {
+			if (stage > 0) {
+				PmAlgorithmUtils.unembedAll(sNet, vNets);
+			}
+
+			System.out.println("=> Starting pipeline stage #" + (++stage));
+			if (algo.execute()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks the overall resource availability for all nodes of all virtual
+	 * networks and all nodes of the substrate network. If a network can not be
+	 * placed on the substrate network at all, the method adds it to the set of
+	 * ignored networks.
+	 */
+	protected void checkOverallResources() {
+		// Calculate total residual resources for substrate servers
+		// Datatype long is needed, because of the possible large values of substrate
+		// server residual
+		// resources (e.g. from the diss scenario).
+		long subTotalResidualCpu = 0;
+		long subTotalResidualMem = 0;
+		long subTotalResidualSto = 0;
+
+		for (final Node n : sNet.getNodess()) {
+			if (n instanceof SubstrateServer) {
+				final SubstrateServer ssrv = (SubstrateServer) n;
+				subTotalResidualCpu += ssrv.getResidualCpu();
+				subTotalResidualMem += ssrv.getResidualMemory();
+				subTotalResidualSto += ssrv.getResidualStorage();
+			}
+		}
+
+		for (final VirtualNetwork vNet : vNets) {
+			// Calculate needed resources for current virtual network candidate
+			long virtTotalCpu = 0;
+			long virtTotalMem = 0;
+			long virtTotalSto = 0;
+
+			for (final Node n : vNet.getNodess()) {
+				if (n instanceof VirtualServer) {
+					final VirtualServer vsrv = (VirtualServer) n;
+					virtTotalCpu += vsrv.getCpu();
+					virtTotalMem += vsrv.getMemory();
+					virtTotalSto += vsrv.getStorage();
+				}
+			}
+
+			if (!(subTotalResidualCpu >= virtTotalCpu && subTotalResidualMem >= virtTotalMem
+					&& subTotalResidualSto >= virtTotalSto)) {
+				ignoredVnets.add(vNet);
+			}
+		}
+	}
+
+	/*
+	 * Helper methods.
+	 */
+
+	/**
+	 * Repairs the consistency of the substrate network. This is necessary, if a
+	 * virtual network was removed "dirty" from the model and the residual values or
+	 * guest references are not updated properly.
+	 */
+	protected void repairSubstrateNetwork() {
+		// Find all networks that were removed in the meantime
+		final Set<VirtualNetwork> removedGuests = sNet.getGuests().stream()
+				.filter(g -> !modelFacade.networkExists(g.getName())).collect(Collectors.toSet());
+
+		// Remove embedding of all elements of the virtual network
+		removedGuests.forEach(g -> modelFacade.unembedVirtualNetwork(g));
+	}
+
+	/**
+	 * Repairs the consistency of all virtual networks. This is necessary if a
+	 * substrate server was removed "dirty" from the model and the previously
+	 * embedded virtual network is in a floating state. After detecting this state,
+	 * the virtual network's embedding will be removed and it has to be embedded
+	 * again.
+	 *
+	 * @return Set of virtual networks that have to be embedded again, because their
+	 *         old embedding was invalid.
+	 */
+	protected Set<VirtualNetwork> repairVirtualNetworks() {
+		// Find all virtual networks that are floating
+		final Set<VirtualNetwork> floatingGuests = sNet.getGuests().stream().filter(g -> modelFacade.checkIfFloating(g))
+				.collect(Collectors.toSet());
+
+		// Remove embedding of all elements of the virtual network so they can be
+		// embedded again
+		floatingGuests.forEach(g -> modelFacade.unembedVirtualNetwork(g));
+		return floatingGuests;
+	}
+
+	/**
+	 * Checks every condition necessary to run this algorithm. If a condition is not
+	 * met, it throws an UnsupportedOperationException.
+	 */
+	protected void checkPreConditions() {
+		// Path creation has to be enabled for paths with length = 1
+		if (ModelFacadeConfig.MIN_PATH_LENGTH != 1) {
+			throw new UnsupportedOperationException("Minimum path length must be 1.");
+		}
+
+		// There must be generated substrate paths
+		if (sNet.getPaths().isEmpty()) {
+			throw new UnsupportedOperationException("Generated paths are missing in substrate network.");
+		}
+	}
+
+	/**
+	 * Initializes the algorithm by creating a new incremental solver object and a
+	 * new pattern matcher object.
+	 */
+	public void init() {
+		// Create new ILP solver object on every method call.
+		ilpSolver = IlpSolverConfig.getIlpSolver();
+
+		if (patternMatcher == null) {
+			patternMatcher = new EmoflonGtFactory().create();
+		}
+	}
+
+}

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvnePipelineAlgorithm.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvnePipelineAlgorithm.java
@@ -132,8 +132,6 @@ public abstract class VnePmMdvnePipelineAlgorithm extends VnePmMdvneAlgorithm im
 		super.prepare(sNet, vNets);
 
 		checkPreConditions();
-
-		AlgorithmPipeline.super.prepare(sNet, vNets);
 	}
 
 	/**

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvnePipelineAlgorithm.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvnePipelineAlgorithm.java
@@ -69,26 +69,38 @@ public abstract class VnePmMdvnePipelineAlgorithm extends VnePmMdvneAlgorithm im
 	protected final Set<VirtualNetwork> ignoredVnets = new HashSet<>();
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvnePipelineAlgorithm() {
 		this(ModelFacade.getInstance());
 	}
 
+	/**
+	 * Initialize the algorithm with the global model facade and the given pipeline
+	 * of algorithms.
+	 * 
+	 * @param pipeline The algorithms to be used in the pipeline.
+	 */
 	public VnePmMdvnePipelineAlgorithm(final Collection<AbstractAlgorithm> pipeline) {
 		this(ModelFacade.getInstance(), pipeline);
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvnePipelineAlgorithm(final ModelFacade modelFacade) {
 		this(modelFacade, List.of());
 	}
 
+	/**
+	 * Initialize the algorithm with the given model facade and the given pipeline
+	 * of algorithms.
+	 * 
+	 * @param modelFacade Model facade to work with.
+	 * @param pipeline    The algorithms to be used in the pipeline.
+	 */
 	public VnePmMdvnePipelineAlgorithm(final ModelFacade modelFacade, final Collection<AbstractAlgorithm> pipeline) {
 		super(modelFacade);
 
@@ -137,7 +149,7 @@ public abstract class VnePmMdvnePipelineAlgorithm extends VnePmMdvneAlgorithm im
 		}
 
 		super.dispose();
-		AlgorithmPipeline.super.dispose(sNet, vNets);
+		AlgorithmPipeline.super.dispose();
 	}
 
 	@Override

--- a/vne.algorithms/src/algorithms/pm/VnePmMdvnePipelineAlgorithm.java
+++ b/vne.algorithms/src/algorithms/pm/VnePmMdvnePipelineAlgorithm.java
@@ -172,6 +172,9 @@ public abstract class VnePmMdvnePipelineAlgorithm extends VnePmMdvneAlgorithm im
 
 		int stage = 0;
 		for (AbstractAlgorithm algo : pipeline) {
+			// Run algorithm preparation again because the substrate network or the set of
+			// virtual networks may have changed because of the repairing above.
+			algo.prepare(sNet, vNets);
 			if (stage > 0) {
 				PmAlgorithmUtils.unembedAll(sNet, vNets);
 			}

--- a/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageRackA.java
+++ b/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageRackA.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import algorithms.AlgorithmConfig;
 import algorithms.pm.VnePmMdvneAlgorithm;
+import facade.ModelFacade;
 import gt.IncrementalPatternMatcher;
 import gt.PatternMatchingDelta;
 import gt.PatternMatchingDelta.Match;
@@ -15,7 +16,6 @@ import gt.emoflon.EmoflonGtRackAFactory;
 import ilp.wrapper.config.IlpSolverConfig;
 import metrics.manager.GlobalMetricsManager;
 import model.SubstrateElement;
-import model.SubstrateNetwork;
 import model.VirtualElement;
 import model.VirtualNetwork;
 
@@ -29,11 +29,6 @@ import model.VirtualNetwork;
 public class VnePmMdvneAlgorithmPipelineStageRackA extends VnePmMdvneAlgorithm {
 
 	/**
-	 * Algorithm instance (singleton).
-	 */
-	protected static VnePmMdvneAlgorithmPipelineStageRackA instance;
-
-	/**
 	 * Incremental pattern matcher to use for the second pipeline stage.
 	 */
 	protected IncrementalPatternMatcher patternMatcherRack;
@@ -44,36 +39,15 @@ public class VnePmMdvneAlgorithmPipelineStageRackA extends VnePmMdvneAlgorithm {
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VnePmMdvneAlgorithmPipelineStageRackA(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithmPipelineStageRackA() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Initializes a new instance of the VNE pattern matching algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
+	 * Constructor.
 	 */
-	public static VnePmMdvneAlgorithmPipelineStageRackA prepare(final SubstrateNetwork sNet,
-			final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
-
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithmPipelineStageRackA(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		instance.checkPreConditions();
-		return instance;
+	public VnePmMdvneAlgorithmPipelineStageRackA(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	/**
@@ -81,9 +55,6 @@ public class VnePmMdvneAlgorithmPipelineStageRackA extends VnePmMdvneAlgorithm {
 	 */
 	@Override
 	public void dispose() {
-		if (instance == null) {
-			return;
-		}
 		if (this.ilpSolver != null) {
 			this.ilpSolver.dispose();
 		}
@@ -94,7 +65,6 @@ public class VnePmMdvneAlgorithmPipelineStageRackA extends VnePmMdvneAlgorithm {
 			this.patternMatcherRack.dispose();
 		}
 		super.dispose();
-		instance = null;
 	}
 
 	@Override
@@ -207,7 +177,7 @@ public class VnePmMdvneAlgorithmPipelineStageRackA extends VnePmMdvneAlgorithm {
 
 		// Workaround to fix the residual bandwidth of other paths possibly affected by
 		// virtual link to substrate path embeddings
-		facade.updateAllPathsResidualBandwidth(sNet.getName());
+		modelFacade.updateAllPathsResidualBandwidth(sNet.getName());
 
 		return rejectedNetworks;
 	}

--- a/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageRackA.java
+++ b/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageRackA.java
@@ -34,17 +34,16 @@ public class VnePmMdvneAlgorithmPipelineStageRackA extends VnePmMdvneAlgorithm {
 	protected IncrementalPatternMatcher patternMatcherRack;
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmPipelineStageRackA() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmPipelineStageRackA(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageRackB.java
+++ b/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageRackB.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import algorithms.AlgorithmConfig;
 import algorithms.pm.VnePmMdvneAlgorithm;
+import facade.ModelFacade;
 import gt.IncrementalPatternMatcher;
 import gt.PatternMatchingDelta;
 import gt.PatternMatchingDelta.Match;
@@ -15,7 +16,6 @@ import gt.emoflon.EmoflonGtRackBFactory;
 import ilp.wrapper.config.IlpSolverConfig;
 import metrics.manager.GlobalMetricsManager;
 import model.SubstrateElement;
-import model.SubstrateNetwork;
 import model.VirtualElement;
 import model.VirtualNetwork;
 
@@ -29,11 +29,6 @@ import model.VirtualNetwork;
 public class VnePmMdvneAlgorithmPipelineStageRackB extends VnePmMdvneAlgorithm {
 
 	/**
-	 * Algorithm instance (singleton).
-	 */
-	protected static VnePmMdvneAlgorithmPipelineStageRackB instance;
-
-	/**
 	 * Incremental pattern matcher to use for the second pipeline stage.
 	 */
 	protected IncrementalPatternMatcher patternMatcherRack;
@@ -44,36 +39,15 @@ public class VnePmMdvneAlgorithmPipelineStageRackB extends VnePmMdvneAlgorithm {
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VnePmMdvneAlgorithmPipelineStageRackB(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithmPipelineStageRackB() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Initializes a new instance of the VNE pattern matching algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
+	 * Constructor.
 	 */
-	public static VnePmMdvneAlgorithmPipelineStageRackB prepare(final SubstrateNetwork sNet,
-			final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
-
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithmPipelineStageRackB(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		instance.checkPreConditions();
-		return instance;
+	public VnePmMdvneAlgorithmPipelineStageRackB(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	/**
@@ -81,9 +55,6 @@ public class VnePmMdvneAlgorithmPipelineStageRackB extends VnePmMdvneAlgorithm {
 	 */
 	@Override
 	public void dispose() {
-		if (instance == null) {
-			return;
-		}
 		if (this.ilpSolver != null) {
 			this.ilpSolver.dispose();
 		}
@@ -94,7 +65,6 @@ public class VnePmMdvneAlgorithmPipelineStageRackB extends VnePmMdvneAlgorithm {
 			this.patternMatcherRack.dispose();
 		}
 		super.dispose();
-		instance = null;
 	}
 
 	@Override
@@ -207,7 +177,7 @@ public class VnePmMdvneAlgorithmPipelineStageRackB extends VnePmMdvneAlgorithm {
 
 		// Workaround to fix the residual bandwidth of other paths possibly affected by
 		// virtual link to substrate path embeddings
-		facade.updateAllPathsResidualBandwidth(sNet.getName());
+		modelFacade.updateAllPathsResidualBandwidth(sNet.getName());
 
 		return rejectedNetworks;
 	}

--- a/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageRackB.java
+++ b/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageRackB.java
@@ -34,17 +34,16 @@ public class VnePmMdvneAlgorithmPipelineStageRackB extends VnePmMdvneAlgorithm {
 	protected IncrementalPatternMatcher patternMatcherRack;
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmPipelineStageRackB() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmPipelineStageRackB(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageVnet.java
+++ b/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageVnet.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import algorithms.AlgorithmConfig;
 import algorithms.pm.VnePmMdvneAlgorithm;
+import facade.ModelFacade;
 import gt.IncrementalPatternMatcher;
 import gt.PatternMatchingDelta;
 import gt.PatternMatchingDelta.Match;
@@ -78,11 +79,6 @@ public class VnePmMdvneAlgorithmPipelineStageVnet extends VnePmMdvneAlgorithm {
 	}
 
 	/**
-	 * Algorithm instance (singleton).
-	 */
-	protected static VnePmMdvneAlgorithmPipelineStageVnet instance;
-
-	/**
 	 * Incremental pattern matcher to use for the first pipeline stage.
 	 */
 	protected IncrementalPatternMatcher patternMatcherVnet;
@@ -93,36 +89,15 @@ public class VnePmMdvneAlgorithmPipelineStageVnet extends VnePmMdvneAlgorithm {
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	protected VnePmMdvneAlgorithmPipelineStageVnet(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public VnePmMdvneAlgorithmPipelineStageVnet() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Initializes a new instance of the VNE pattern matching algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
-	 * @return Instance of this algorithm implementation.
+	 * Constructor.
 	 */
-	public static VnePmMdvneAlgorithmPipelineStageVnet prepare(final SubstrateNetwork sNet,
-			final Set<VirtualNetwork> vNets) {
-		if (sNet == null || vNets == null) {
-			throw new IllegalArgumentException("One of the provided network objects was null.");
-		}
-
-		if (vNets.size() == 0) {
-			throw new IllegalArgumentException("Provided set of virtual networks was empty.");
-		}
-
-		if (instance == null) {
-			instance = new VnePmMdvneAlgorithmPipelineStageVnet(sNet, vNets);
-		}
-		instance.sNet = sNet;
-		instance.vNets = new HashSet<>();
-		instance.vNets.addAll(vNets);
-
-		instance.checkPreConditions();
-		return instance;
+	public VnePmMdvneAlgorithmPipelineStageVnet(final ModelFacade modelFacade) {
+		super(modelFacade);
 	}
 
 	/**
@@ -130,9 +105,6 @@ public class VnePmMdvneAlgorithmPipelineStageVnet extends VnePmMdvneAlgorithm {
 	 */
 	@Override
 	public void dispose() {
-		if (instance == null) {
-			return;
-		}
 		if (this.ilpSolver != null) {
 			this.ilpSolver.dispose();
 		}
@@ -143,7 +115,6 @@ public class VnePmMdvneAlgorithmPipelineStageVnet extends VnePmMdvneAlgorithm {
 			this.patternMatcherVnet.dispose();
 		}
 		super.dispose();
-		instance = null;
 	}
 
 	@Override
@@ -307,7 +278,7 @@ public class VnePmMdvneAlgorithmPipelineStageVnet extends VnePmMdvneAlgorithm {
 
 		// Workaround to fix the residual bandwidth of other paths possibly affected by
 		// virtual link to substrate path embeddings
-		facade.updateAllPathsResidualBandwidth(sNet.getName());
+		modelFacade.updateAllPathsResidualBandwidth(sNet.getName());
 
 		return rejectedNetworks;
 	}

--- a/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageVnet.java
+++ b/vne.algorithms/src/algorithms/pm/stages/VnePmMdvneAlgorithmPipelineStageVnet.java
@@ -84,17 +84,16 @@ public class VnePmMdvneAlgorithmPipelineStageVnet extends VnePmMdvneAlgorithm {
 	protected IncrementalPatternMatcher patternMatcherVnet;
 
 	/**
-	 * Constructor that gets the substrate as well as the virtual network.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public VnePmMdvneAlgorithmPipelineStageVnet() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public VnePmMdvneAlgorithmPipelineStageVnet(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/random/RandomVneAlgorithm.java
+++ b/vne.algorithms/src/algorithms/random/RandomVneAlgorithm.java
@@ -36,10 +36,7 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 	private int retries = 10;
 
 	/**
-	 * Initializes a new object of this random VNE algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public RandomVneAlgorithm() {
 		this(ModelFacade.getInstance());
@@ -59,14 +56,20 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public RandomVneAlgorithm(final ModelFacade modelFacade) {
 		super(modelFacade);
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
+	 * @param randomSeed  Random seed.
+	 * @param retries     Number of retries.
 	 */
 	public RandomVneAlgorithm(final ModelFacade modelFacade, final int randomSeed, final int retries) {
 		this(modelFacade);

--- a/vne.algorithms/src/algorithms/random/RandomVneAlgorithm.java
+++ b/vne.algorithms/src/algorithms/random/RandomVneAlgorithm.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import java.util.Set;
 
 import algorithms.AbstractAlgorithm;
+import facade.ModelFacade;
 import facade.config.ModelFacadeConfig;
 import model.Link;
 import model.Node;
@@ -40,18 +41,8 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	public RandomVneAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
-
-		if (vNets.size() != 1) {
-			throw new IllegalArgumentException(
-					"The random VNE algorithm is only suited for one virtual network at a time.");
-		}
-
-		// Check pre-conditions
-		checkPreConditions();
-
-		retries = sNet.getNodess().size() * 2;
+	public RandomVneAlgorithm() {
+		this(ModelFacade.getInstance());
 	}
 
 	/**
@@ -63,17 +54,46 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 	 * @param randomSeed Random seed.
 	 * @param retries    Number of retries.
 	 */
-	public RandomVneAlgorithm(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets, final int randomSeed,
-			final int retries) {
-		this(sNet, vNets);
+	public RandomVneAlgorithm(final int randomSeed, final int retries) {
+		this(ModelFacade.getInstance(), randomSeed, retries);
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public RandomVneAlgorithm(final ModelFacade modelFacade) {
+		super(modelFacade);
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public RandomVneAlgorithm(final ModelFacade modelFacade, final int randomSeed, final int retries) {
+		this(modelFacade);
+
 		randGen.setSeed(randomSeed);
 		this.retries = retries;
 	}
 
 	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
+		if (vNets.size() != 1) {
+			throw new IllegalArgumentException(
+					"The random VNE algorithm is only suited for one virtual network at a time.");
+		}
+
+		super.prepare(sNet, vNets);
+
+		// Check pre-conditions
+		checkPreConditions();
+
+		retries = sNet.getNodess().size() * 2;
+	}
+
+	@Override
 	public boolean execute() {
-		final List<Node> subServers = facade.getAllServersOfNetwork(sNet.getName());
-		final List<Node> subSwitches = facade.getAllSwitchesOfNetwork(sNet.getName());
+		final List<Node> subServers = modelFacade.getAllServersOfNetwork(sNet.getName());
+		final List<Node> subSwitches = modelFacade.getAllSwitchesOfNetwork(sNet.getName());
 		final List<Node> allNodes = new LinkedList<Node>();
 		allNodes.addAll(subSwitches);
 		allNodes.addAll(subServers);
@@ -88,7 +108,7 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 		final VirtualNetwork vNet = vNets.iterator().next();
 
 		// Embed virtual network
-		success &= facade.embedNetworkToNetwork(sNet.getName(), vNet.getName());
+		success &= modelFacade.embedNetworkToNetwork(sNet.getName(), vNet.getName());
 		if (success) {
 			embeddedIds.add(vNet.getName());
 		}
@@ -101,7 +121,7 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 				boolean serverSuccess = true;
 				for (int i = 0; i < retries; i++) {
 					try {
-						facade.embedServerToServer(sserver.getName(), vserver.getName());
+						modelFacade.embedServerToServer(sserver.getName(), vserver.getName());
 						embeddedIds.add(vserver.getName());
 						serverSuccess = true;
 						break;
@@ -114,7 +134,7 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 				success &= serverSuccess;
 			} else if (vnode instanceof VirtualSwitch vswitch) {
 				final SubstrateNode snode = (SubstrateNode) allNodes.get(rand(allNodes.size()));
-				success &= facade.embedSwitchToNode(snode.getName(), vswitch.getName());
+				success &= modelFacade.embedSwitchToNode(snode.getName(), vswitch.getName());
 
 				if (success) {
 					embeddedIds.add(vswitch.getName());
@@ -138,7 +158,7 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 				// If both, the source and the target of a virtual link are embedded to the same
 				// substrate node, also use this node for the embedding of the virtual link.
 				if (vsourceHost.equals(vtargetHost)) {
-					success &= facade.embedGeneric(vsourceHost.getName(), vLink.getName());
+					success &= modelFacade.embedGeneric(vsourceHost.getName(), vLink.getName());
 
 					if (success) {
 						embeddedIds.add(vLink.getName());
@@ -146,10 +166,10 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 				} else {
 					// If source and target host are not the same node, find the corresponding path
 					// between the two nodes.
-					final SubstratePath sPath = facade.getPathFromSourceToTarget(vsourceHost.getName(),
+					final SubstratePath sPath = modelFacade.getPathFromSourceToTarget(vsourceHost.getName(),
 							vtargetHost.getName());
 					try {
-						facade.embedGeneric(sPath.getName(), vLink.getName());
+						modelFacade.embedGeneric(sPath.getName(), vLink.getName());
 						embeddedIds.add(vLink.getName());
 					} catch (final UnsupportedOperationException ex) {
 						success = false;
@@ -161,7 +181,7 @@ public class RandomVneAlgorithm extends AbstractAlgorithm {
 		// If at least one element could not be embedded, all other embeddings must be
 		// removed.
 		if (!success) {
-			facade.unembedVirtualNetwork((VirtualNetwork) facade.getNetworkById(vNet.getName()));
+			modelFacade.unembedVirtualNetwork((VirtualNetwork) modelFacade.getNetworkById(vNet.getName()));
 		}
 
 		return success;

--- a/vne.algorithms/src/algorithms/simple/SimpleVne.java
+++ b/vne.algorithms/src/algorithms/simple/SimpleVne.java
@@ -23,17 +23,16 @@ import model.VirtualServer;
 public class SimpleVne extends AbstractAlgorithm {
 
 	/**
-	 * Initializes a new object of this simple VNE algorithm.
-	 *
-	 * @param sNet  Substrate network to work with.
-	 * @param vNets Set of virtual networks to work with.
+	 * Initialize the algorithm with the global model facade.
 	 */
 	public SimpleVne() {
 		this(ModelFacade.getInstance());
 	}
 
 	/**
-	 * Constructor.
+	 * Initialize the algorithm with the given model facade.
+	 * 
+	 * @param modelFacade Model facade to work with.
 	 */
 	public SimpleVne(final ModelFacade modelFacade) {
 		super(modelFacade);

--- a/vne.algorithms/src/algorithms/simple/SimpleVne.java
+++ b/vne.algorithms/src/algorithms/simple/SimpleVne.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 
 import algorithms.AbstractAlgorithm;
+import facade.ModelFacade;
 import model.Link;
 import model.Node;
 import model.SubstrateNetwork;
@@ -27,18 +28,30 @@ public class SimpleVne extends AbstractAlgorithm {
 	 * @param sNet  Substrate network to work with.
 	 * @param vNets Set of virtual networks to work with.
 	 */
-	public SimpleVne(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
-		super(sNet, vNets);
+	public SimpleVne() {
+		this(ModelFacade.getInstance());
+	}
 
+	/**
+	 * Constructor.
+	 */
+	public SimpleVne(final ModelFacade modelFacade) {
+		super(modelFacade);
+	}
+
+	@Override
+	public void prepare(final SubstrateNetwork sNet, final Set<VirtualNetwork> vNets) {
 		if (vNets.size() != 1) {
 			throw new IllegalArgumentException(
 					"The simple VNE algorithm is only suited for one virtual network at a time.");
 		}
+
+		super.prepare(sNet, vNets);
 	}
 
 	@Override
 	public boolean execute() {
-		final List<Node> subServers = facade.getAllServersOfNetwork(sNet.getName());
+		final List<Node> subServers = modelFacade.getAllServersOfNetwork(sNet.getName());
 		String largestServerId = "";
 		long largestServerRes = Long.MAX_VALUE;
 
@@ -57,14 +70,14 @@ public class SimpleVne extends AbstractAlgorithm {
 		int summedMem = 0;
 		int summedStor = 0;
 
-		for (Node actNode : facade.getAllServersOfNetwork(getFirstVnet().getName())) {
+		for (Node actNode : modelFacade.getAllServersOfNetwork(getFirstVnet().getName())) {
 			final VirtualServer actServer = (VirtualServer) actNode;
 			summedCpu += actServer.getCpu();
 			summedMem += actServer.getMemory();
 			summedMem += actServer.getStorage();
 		}
 
-		final SubstrateServer largestSubServer = (SubstrateServer) facade.getServerById(largestServerId);
+		final SubstrateServer largestSubServer = (SubstrateServer) modelFacade.getServerById(largestServerId);
 
 		if (!(summedCpu <= largestSubServer.getResidualCpu() && summedMem <= largestSubServer.getResidualMemory()
 				&& summedStor <= largestSubServer.getResidualStorage())) {
@@ -79,21 +92,21 @@ public class SimpleVne extends AbstractAlgorithm {
 		boolean success = true;
 
 		// Network
-		success &= facade.embedNetworkToNetwork(sNet.getName(), getFirstVnet().getName());
+		success &= modelFacade.embedNetworkToNetwork(sNet.getName(), getFirstVnet().getName());
 
 		// Servers
-		for (Node act : facade.getAllServersOfNetwork(getFirstVnet().getName())) {
-			success &= facade.embedServerToServer(largestServerId, act.getName());
+		for (Node act : modelFacade.getAllServersOfNetwork(getFirstVnet().getName())) {
+			success &= modelFacade.embedServerToServer(largestServerId, act.getName());
 		}
 
 		// Switches
-		for (Node act : facade.getAllSwitchesOfNetwork(getFirstVnet().getName())) {
-			success &= facade.embedSwitchToNode(largestServerId, act.getName());
+		for (Node act : modelFacade.getAllSwitchesOfNetwork(getFirstVnet().getName())) {
+			success &= modelFacade.embedSwitchToNode(largestServerId, act.getName());
 		}
 
 		// Links
-		for (Link act : facade.getAllLinksOfNetwork(getFirstVnet().getName())) {
-			success &= facade.embedLinkToServer(largestServerId, act.getName());
+		for (Link act : modelFacade.getAllLinksOfNetwork(getFirstVnet().getName())) {
+			success &= modelFacade.embedLinkToServer(largestServerId, act.getName());
 		}
 
 		return success;

--- a/vne.scenarios/src/scenarios/gen/MdvneAdaptedScenario.java
+++ b/vne.scenarios/src/scenarios/gen/MdvneAdaptedScenario.java
@@ -56,7 +56,8 @@ public class MdvneAdaptedScenario extends AMdvneAdaptedScenario implements IScen
 			scen.virtualSetup(virtualNetworkId);
 			final VirtualNetwork virt = (VirtualNetwork) facade.getNetworkById(virtualNetworkId);
 			// TODO: Change the algorithm instance later on.
-			final AbstractAlgorithm algo = new TafAlgorithm(sub, Set.of(virt));
+			final AbstractAlgorithm algo = new TafAlgorithm();
+			algo.prepare(sub, Set.of(virt));
 			final boolean success = algo.execute();
 
 			if (success) {

--- a/vne.scenarios/src/scenarios/gen/MdvneFatTreeAdaptedScenario.java
+++ b/vne.scenarios/src/scenarios/gen/MdvneFatTreeAdaptedScenario.java
@@ -63,7 +63,8 @@ public class MdvneFatTreeAdaptedScenario extends AMdvneAdaptedScenario implement
 			scen.virtualSetup(virtualNetworkId);
 			final VirtualNetwork virt = (VirtualNetwork) facade.getNetworkById(virtualNetworkId);
 			// TODO: Change the algorithm instance later on.
-			final AbstractAlgorithm algo = new TafAlgorithm(sub, Set.of(virt));
+			final AbstractAlgorithm algo = new TafAlgorithm();
+			algo.prepare(sub, Set.of(virt));
 			final boolean success = algo.execute();
 
 			if (success) {

--- a/vne.scenarios/src/scenarios/gen/OptimalVmScenario.java
+++ b/vne.scenarios/src/scenarios/gen/OptimalVmScenario.java
@@ -114,7 +114,8 @@ public class OptimalVmScenario implements IScenario {
 			virtualSetup(virtualNetworkId);
 			final VirtualNetwork virt = (VirtualNetwork) facade.getNetworkById(virtualNetworkId);
 			// TODO: Change the algorithm instance later on.
-			final AbstractAlgorithm algo = new TafAlgorithm(sub, Set.of(virt));
+			final AbstractAlgorithm algo = new TafAlgorithm();
+			algo.prepare(sub, Set.of(virt));
 			final boolean success = algo.execute();
 
 			if (success) {

--- a/vne.scenarios/src/scenarios/load/DissScenarioLoad.java
+++ b/vne.scenarios/src/scenarios/load/DissScenarioLoad.java
@@ -3,6 +3,7 @@ package scenarios.load;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -70,11 +71,6 @@ public class DissScenarioLoad {
 	protected static SubstrateNetwork sNet;
 
 	/**
-	 * Configured algorithm to use for every embedding.
-	 */
-	protected static String algoConfig;
-
-	/**
 	 * File path for the JSON file to load the substrate network from.
 	 */
 	protected static String subNetPath;
@@ -88,6 +84,11 @@ public class DissScenarioLoad {
 	 * File path for the metric CSV output.
 	 */
 	protected static String csvPath = null;
+
+	/**
+	 * The algorithm to use
+	 */
+	protected static Function<ModelFacade, AbstractAlgorithm> algoFactory = null;
 
 	/**
 	 * Main method to start the example. String array of arguments will be parsed.
@@ -117,6 +118,7 @@ public class DissScenarioLoad {
 		 */
 
 		String vNetId = IncrementalModelConverter.jsonToModelIncremental(virtNetsPath, true);
+		final AbstractAlgorithm algo = algoFactory.apply(ModelFacade.getInstance());
 
 		while (vNetId != null) {
 			final VirtualNetwork vNet = (VirtualNetwork) ModelFacade.getInstance().getNetworkById(vNetId);
@@ -124,7 +126,7 @@ public class DissScenarioLoad {
 			System.out.println("=> Embedding virtual network " + vNetId);
 
 			// Create and execute algorithm
-			final AbstractAlgorithm algo = newAlgo(Set.of(vNet));
+			algo.prepare(sNet, Set.of(vNet));
 			GlobalMetricsManager.startRuntime();
 			algo.execute();
 			GlobalMetricsManager.stopRuntime();
@@ -284,7 +286,8 @@ public class DissScenarioLoad {
 		// Parsing finished. Here starts the configuration.
 
 		// #0 Algorithm
-		algoConfig = cmd.getOptionValue("algorithm");
+		final String algoConfig = cmd.getOptionValue("algorithm");
+		algoFactory = getAlgoFactory(algoConfig);
 
 		// #1 Objective
 		switch (cmd.getOptionValue("objective")) {
@@ -394,40 +397,40 @@ public class DissScenarioLoad {
 	 *
 	 * @param vNets Virtual network(s) to embed.
 	 */
-	protected static AbstractAlgorithm newAlgo(final Set<VirtualNetwork> vNets) {
+	protected static Function<ModelFacade, AbstractAlgorithm> getAlgoFactory(final String algoConfig) {
 		switch (algoConfig) {
 		case "pm":
-			return VnePmMdvneAlgorithm.prepare(sNet, vNets);
+			return VnePmMdvneAlgorithm::new;
 		case "pm-migration":
-			return VnePmMdvneAlgorithmMigration.prepare(sNet, vNets);
+			return VnePmMdvneAlgorithmMigration::new;
 		case "pm-pipeline2-vnet":
-			return VnePmMdvneAlgorithmPipelineTwoStagesVnet.prepare(sNet, vNets);
+			return VnePmMdvneAlgorithmPipelineTwoStagesVnet::new;
 		case "pm-pipeline2-racka":
-			return VnePmMdvneAlgorithmPipelineTwoStagesRackA.prepare(sNet, vNets);
+			return VnePmMdvneAlgorithmPipelineTwoStagesRackA::new;
 		case "pm-pipeline2-rackb":
-			return VnePmMdvneAlgorithmPipelineTwoStagesRackB.prepare(sNet, vNets);
+			return VnePmMdvneAlgorithmPipelineTwoStagesRackB::new;
 		case "pm-pipeline3a":
-			return VnePmMdvneAlgorithmPipelineThreeStagesA.prepare(sNet, vNets);
+			return VnePmMdvneAlgorithmPipelineThreeStagesA::new;
 		case "pm-pipeline3b":
-			return VnePmMdvneAlgorithmPipelineThreeStagesB.prepare(sNet, vNets);
+			return VnePmMdvneAlgorithmPipelineThreeStagesB::new;
 		case "ilp":
-			return VneFakeIlpAlgorithm.prepare(sNet, vNets);
+			return VneFakeIlpAlgorithm::new;
 		case "ilp-batch":
-			return VneFakeIlpBatchAlgorithm.prepare(sNet, vNets);
+			return VneFakeIlpBatchAlgorithm::new;
 		case "gips":
-			return VneGipsAlgorithm.prepare(sNet, vNets);
+			return VneGipsAlgorithm::new;
 		case "gips-mig":
-			return VneGipsMigrationAlgorithm.prepare(sNet, vNets);
+			return VneGipsMigrationAlgorithm::new;
 		case "gips-seq":
-			return VneGipsSeqAlgorithm.prepare(sNet, vNets);
+			return VneGipsSeqAlgorithm::new;
 		case "gips-bwignore":
-			return VneGipsBwIgnoreAlgorithm.prepare(sNet, vNets);
+			return VneGipsBwIgnoreAlgorithm::new;
 		case "taf":
 			ModelFacadeConfig.IGNORE_BW = true;
-			return new TafAlgorithm(sNet, vNets);
+			return TafAlgorithm::new;
 		case "random":
 			ModelFacadeConfig.IGNORE_BW = true;
-			return new RandomVneAlgorithm(sNet, vNets);
+			return RandomVneAlgorithm::new;
 		default:
 			throw new IllegalArgumentException("Configured algorithm not known.");
 		}

--- a/vne.scenarios/src/scenarios/load/DissScenarioLoad.java
+++ b/vne.scenarios/src/scenarios/load/DissScenarioLoad.java
@@ -91,6 +91,17 @@ public class DissScenarioLoad {
 	protected static Function<ModelFacade, AbstractAlgorithm> algoFactory = null;
 
 	/**
+	 * If the model should be persisted after execution, optionally supply the file
+	 * name.
+	 */
+	protected static boolean persistModel = false;
+
+	/**
+	 * The path to the file where the model should be persisted.
+	 */
+	protected static String persistModelPath;
+
+	/**
 	 * Main method to start the example. String array of arguments will be parsed.
 	 *
 	 * @param args See {@link #parseArgs(String[])}.
@@ -141,6 +152,15 @@ public class DissScenarioLoad {
 
 			// Get next virtual network ID to embed
 			vNetId = IncrementalModelConverter.jsonToModelIncremental(virtNetsPath, true);
+
+			// Save model to file
+			if (persistModel) {
+				if (persistModelPath == null) {
+					ModelFacade.getInstance().persistModel();
+				} else {
+					ModelFacade.getInstance().persistModel(persistModelPath);
+				}
+			}
 		}
 
 		/*
@@ -157,8 +177,6 @@ public class DissScenarioLoad {
 		// Print metrics before saving the model
 		printMetrics();
 
-		// Save model to file
-		ModelFacade.getInstance().persistModel();
 		System.out.println("=> Execution finished.");
 		System.exit(0);
 	}
@@ -270,6 +288,14 @@ public class DissScenarioLoad {
 		final Option ilpObjLog = new Option("x", "ilpobjlog", false, "ILP solver objective logarithm");
 		ilpObjLog.setRequired(false);
 		options.addOption(ilpObjLog);
+
+		// Model: Persist after run
+		final Option modelPersist = new Option("persist-model", true,
+				"If the model should be persisted after execution, optionally supply the file name.");
+		modelPersist.setRequired(false);
+		modelPersist.setOptionalArg(true);
+		modelPersist.setType(String.class);
+		options.addOption(modelPersist);
 
 		final CommandLineParser parser = new DefaultParser();
 		final HelpFormatter formatter = new HelpFormatter();
@@ -387,6 +413,12 @@ public class DissScenarioLoad {
 
 		// #14: ILP solver objective logarithm
 		IlpSolverConfig.OBJ_LOG = cmd.hasOption("ilpobjlog");
+
+		if (cmd.hasOption(modelPersist)) {
+			final String filePath = cmd.getOptionValue(modelPersist, "");
+			persistModel = true;
+			persistModelPath = filePath.isBlank() ? null : filePath;
+		}
 
 		// Print arguments into logs/system outputs
 		System.out.println("=> Arguments: " + Arrays.toString(args));

--- a/vne.scenarios/src/scenarios/load/DissScenarioLoadBatch.java
+++ b/vne.scenarios/src/scenarios/load/DissScenarioLoadBatch.java
@@ -53,7 +53,8 @@ public class DissScenarioLoadBatch extends DissScenarioLoad {
 		vNetIds.forEach(i -> vNets.add((VirtualNetwork) ModelFacade.getInstance().getNetworkById(i)));
 
 		// Create and execute algorithm
-		final AbstractAlgorithm algo = newAlgo(vNets);
+		final AbstractAlgorithm algo = algoFactory.apply(ModelFacade.getInstance());
+		algo.prepare(sNet, vNets);
 
 		GlobalMetricsManager.startRuntime();
 		algo.execute();


### PR DESCRIPTION
- remove the `static` modifier for all VNE algorithms, enabling them to be used as instances
- extend `AbstractAlgorithm` for `GipsAlgorithm`s to provide GIPS solver output
- DissScenarioLoad: add toggle to remove VNs for which embedding failed, to further continue with other VNRs

Depends on Echtzeitsysteme/gips-examples#95